### PR TITLE
Ensure ResourceSynced condition set

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-12-07T12:52:30Z"
-  build_hash: 5ffa7aecf6b688da8c06f91bdc7b342ea2848c3f
+  build_date: "2021-12-10T16:52:22Z"
+  build_hash: 285d87b66b62fbfb859986ddf74c9f9b6ae743fb
   go_version: go1.17
   version: v0.15.2
 api_directory_checksum: d19cbe57322f73edfbc00516371d96a3e7f31c29
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.2
 generator_config_info:
-  file_checksum: 08652a6d39a6e123f4895b062e6bbf04100a1955
+  file_checksum: 0e4f42c57dc98ab50fbc2c3450d2f841891e1936
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -16,6 +16,11 @@ ignore:
    - VirtualMFADevice
 resources:
   Role:
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/role/sdk_create_post_set_output.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/role/sdk_update_post_set_output.go.tpl
     exceptions:
       terminal_codes:
         - InvalidInput

--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:UpdateRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/generator.yaml
+++ b/generator.yaml
@@ -16,6 +16,11 @@ ignore:
    - VirtualMFADevice
 resources:
   Role:
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/role/sdk_create_post_set_output.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/role/sdk_update_post_set_output.go.tpl
     exceptions:
       terminal_codes:
         - InvalidInput

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -75,3 +75,12 @@ spec:
           value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if .Values.deployment.tolerations -}}
+      tolerations: {{ toYaml .Values.deployment.tolerations | nindent 8 }}
+      {{ end -}}
+      {{ if .Values.deployment.affinity -}}
+      affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
+      {{ end -}}
+      {{ if .Values.deployment.priorityClassName -}}
+      priorityClassName: {{ .Values.deployment.priorityClassName -}}
+      {{ end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,9 +15,20 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+  # Which nodeSelector to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
-
+  # Which tolerations to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: {}
+  # What affinity to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  # Which priorityClassName to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+  priorityClassName:
+  
 metrics:
   service:
     # Set to true to automatically create a Kubernetes Service resource for the

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -287,6 +287,11 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// There really isn't a status of a role... it either exists or doesn't. If
+	// we get here, that means the creation was successful and the desired
+	// state of the role matches what we provided...
+	ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
+
 	return &resource{ko}, nil
 }
 
@@ -362,6 +367,11 @@ func (rm *resourceManager) sdkUpdate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
+	// There really isn't a status of a role... it either exists or doesn't. If
+	// we get here, that means the update was successful and the desired state
+	// of the role matches what we provided...
+	ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/role/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,4 @@
+    // There really isn't a status of a role... it either exists or doesn't. If
+    // we get here, that means the creation was successful and the desired
+    // state of the role matches what we provided...
+    ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)

--- a/templates/hooks/role/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_update_post_set_output.go.tpl
@@ -1,0 +1,4 @@
+    // There really isn't a status of a role... it either exists or doesn't. If
+    // we get here, that means the update was successful and the desired state
+    // of the role matches what we provided...
+    ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@8b21fd1a3374f506d35efe7426d5deed8b1bb1bf
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@75752b2

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -18,6 +18,7 @@ import time
 
 import pytest
 
+from acktest.k8s import condition
 from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
@@ -67,7 +68,8 @@ class TestRole:
         assert 'spec' in cr
         assert 'maxSessionDuration' in cr['spec']
         assert cr['spec']['maxSessionDuration'] == max_sess_duration
-        #condition.assert_synced(ref)
+
+        condition.assert_synced(ref)
 
         latest = role.get(role_name)
         assert latest is not None


### PR DESCRIPTION
There really isn't an "active" or "available" status for Role resources
in IAM. Basically, when the role is successfully created or updated,
it's in sync with whatever the desired state of the role was. So, this
patch adds simple setters after successful create and update code paths
that ensures ResourceSynced condition of True is set on the Role CRs.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
