### PR TITLE
support updating Tags on Role resources

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -14,7 +14,10 @@
                 "iam:DeletePolicy",
                 "iam:ListAttachedRolePolicies",
                 "iam:AttachRolePolicy",
-                "iam:DetachRolePolicy"
+                "iam:DetachRolePolicy",
+                "iam:ListRoleTags",
+                "iam:TagRole",
+                "iam:UntagRole"
             ],
             "Resource": "*"
         }

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -160,6 +160,11 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Spec.Policies = policies
 	}
+	if tags, err := rm.getTags(ctx, &resource{ko}); err != nil {
+		return nil, err
+	} else {
+		ko.Spec.Tags = tags
+	}
 
 	rm.setStatusDefaults(ko)
 	return &resource{ko}, nil
@@ -376,6 +381,9 @@ func (rm *resourceManager) sdkUpdate(
 
 	rm.setStatusDefaults(ko)
 	if err := rm.syncPolicies(ctx, &resource{ko}); err != nil {
+		return nil, err
+	}
+	if err := rm.syncTags(ctx, &resource{ko}); err != nil {
 		return nil, err
 	}
 	// There really isn't a status of a role... it either exists or doesn't. If

--- a/templates/hooks/role/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_read_one_post_set_output.go.tpl
@@ -3,3 +3,8 @@
 	} else {
 		ko.Spec.Policies = policies
 	}
+	if tags, err := rm.getTags(ctx, &resource{ko}); err != nil {
+		return nil, err
+	} else {
+		ko.Spec.Tags = tags
+	}

--- a/templates/hooks/role/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_update_post_set_output.go.tpl
@@ -1,6 +1,9 @@
     if err := rm.syncPolicies(ctx, &resource{ko}); err != nil {
         return nil, err
     }
+    if err := rm.syncTags(ctx, &resource{ko}); err != nil {
+        return nil, err
+    }
     // There really isn't a status of a role... it either exists or doesn't. If
     // we get here, that means the update was successful and the desired state
     // of the role matches what we provided...

--- a/test/e2e/resources/role_simple.yaml
+++ b/test/e2e/resources/role_simple.yaml
@@ -7,3 +7,6 @@ spec:
   description: $ROLE_DESCRIPTION
   maxSessionDuration: $MAX_SESSION_DURATION
   assumeRolePolicyDocument: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com"]},"Action":["sts:AssumeRole"]}]}'
+  tags:
+    - key: tag1
+      value: val1

--- a/test/e2e/role.py
+++ b/test/e2e/role.py
@@ -114,3 +114,17 @@ def get_attached_policy_arns(role_name):
         return [p['PolicyArn'] for p in resp['AttachedPolicies']]
     except c.exceptions.NoSuchEntityException:
         return None
+
+
+def get_tags(role_name):
+    """Returns a list containing the tags that have been associated to the
+    supplied Role.
+
+    If no such Role exists, returns None.
+    """
+    c = boto3.client('iam')
+    try:
+        resp = c.list_role_tags(RoleName=role_name)
+        return resp['Tags']
+    except c.exceptions.NoSuchEntityException:
+        return None

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -103,6 +103,36 @@ class TestRole:
         latest_policy_arns = role.get_attached_policy_arns(role_name)
         assert latest_policy_arns == policy_arns
 
+        # Same update code path check for tags...
+        latest_tags = role.get_tags(role_name)
+        before_update_expected_tags = [
+            {
+                "Key": "tag1",
+                "Value": "val1"
+            }
+        ]
+        assert latest_tags == before_update_expected_tags
+        new_tags = [
+            {
+                "key": "tag2",
+                "value": "val2",
+            }
+        ]
+        updates = {
+            "spec": {"tags": new_tags},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        after_update_expected_tags = [
+            {
+                "Key": "tag2",
+                "Value": "val2",
+            }
+        ]
+        latest_tags = role.get_tags(role_name)
+        assert latest_tags == after_update_expected_tags
+
         k8s.delete_custom_resource(ref)
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)


### PR DESCRIPTION
Adds support for updating (adding/removing) Tags from a Role resource in
the IAM controller.

Unfortunately, the "standard" Tagris
ListTagsForResource/TagResource/UntagResource AWS Resource Group Tagging
API calls aren't supported for IAM. You need to use the IAM-specific
TagRole/UntagRole/ListRoleTags IAM API calls to work with tags on Role
resources.

Following patches will add support for the same tags on Policy
resources.

Issue: aws-controllers-k8s/community#1119

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
