### PR TITLE
add random suffix to test resource names

### DIFF
--- a/test/e2e/tests/test_policy.py
+++ b/test/e2e/tests/test_policy.py
@@ -19,6 +19,7 @@ import pytest
 
 from acktest.k8s import condition
 from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
 from e2e.common.types import POLICY_RESOURCE_PLURAL
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -32,7 +33,7 @@ CHECK_WAIT_AFTER_SECONDS = 10
 @pytest.mark.canary
 class TestPolicy:
     def test_crud(self):
-        policy_name = "my-simple-policy"
+        policy_name = random_suffix_name("my-simple-policy", 24)
         policy_desc = "a simple policy"
 
         replacements = REPLACEMENT_VALUES.copy()

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -35,7 +35,7 @@ MODIFY_WAIT_AFTER_SECONDS = 10
 @pytest.mark.canary
 class TestRole:
     def test_crud(self):
-        role_name = "my-simple-role"
+        role_name = random_suffix_name("my-simple-role", 24)
         role_desc = "a simple role"
         max_sess_duration = 3600 # Note: minimum of 3600 seconds...
 


### PR DESCRIPTION
Description of changes:

* Add random suffix to test resource names
* If a test fails and resource does not get cleaned up, this helps prevent `ConflictException` during next test run
* Ideally tests should/will cleanup all the resources, but in the worst case, one resource leak should not block PRs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
