### PR TITLE
Fix invalid input exception when updating tags

### DIFF
--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -166,17 +166,21 @@ func (rm *resourceManager) syncTags(
 		}
 	}
 
-	for _, t := range toAdd {
-		rlog.Debug("adding tag to role", "key", *t.Key, "value", *t.Value)
+	if len(toAdd) > 0 {
+		for _, t := range toAdd {
+			rlog.Debug("adding tag to role", "key", *t.Key, "value", *t.Value)
+		}
+		if err = rm.addTags(ctx, r, toAdd); err != nil {
+			return err
+		}
 	}
-	if err = rm.addTags(ctx, r, toAdd); err != nil {
-		return err
-	}
-	for _, t := range toDelete {
-		rlog.Debug("removing tag from role", "key", *t.Key, "value", *t.Value)
-	}
-	if err = rm.removeTags(ctx, r, toDelete); err != nil {
-		return err
+	if len(toDelete) > 0 {
+		for _, t := range toDelete {
+			rlog.Debug("removing tag from role", "key", *t.Key, "value", *t.Value)
+		}
+		if err = rm.removeTags(ctx, r, toDelete); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Description of changes:
The IAM API will throw an `InvalidInput` exception when attempting to add or delete an empty list of tags. This pull request adds a condition to guard against this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
