### PR TITLE
Add iam:ListPolicyTags to recommended policy

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -16,6 +16,7 @@
                 "iam:CreatePolicyVersion",
                 "iam:DeletePolicyVersion",
                 "iam:ListPolicyVersions",
+                "iam:ListPolicyTags",
                 "iam:ListAttachedRolePolicies",
                 "iam:AttachRolePolicy",
                 "iam:DetachRolePolicy",


### PR DESCRIPTION
Issue #, if available:

- Fixes [aws-controllers-k8s/community/issues/1296](https://github.com/aws-controllers-k8s/community/issues/1296)

Description of changes:
This PR is to add the missing `iam:ListPolicyTags` permission to the policy document.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
