### PR TITLE
correct tag comparisons for Role and Policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-09-12T19:38:51Z"
-  build_hash: 2944c8772f216656d84ee02d392eaca501274c1e
-  go_version: go1.17.5
-  version: v0.20.1
+  build_date: "2022-10-08T13:57:49Z"
+  build_hash: 5ee0ac052c54f008dff50f6f5ebb73f2cf3a0bd7
+  go_version: go1.18.1
+  version: v0.20.1-4-g5ee0ac0
 api_directory_checksum: 9deaf0523c157680935dc914518cb7c9f54c43a7
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: adee4dfc3bba2124bb0b30542295e33fa5387f20
+  file_checksum: 69e0ccd675ad7861f05cf02655a53083ecf9f148
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -28,6 +28,8 @@ resources:
           input_fields:
             PolicyName: Name
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/policy/sdk_read_one_post_set_output.go.tpl
       sdk_delete_pre_build_request:
@@ -65,8 +67,13 @@ resources:
         late_initialize: {}
       Path:
         late_initialize: {}
+      Tags:
+        compare:
+          is_ignored: true
   Role:
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/role/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
@@ -107,3 +114,6 @@ resources:
       # calls to manage the set of PolicyARNs attached to this Role.
       Policies:
         type: "[]*string"
+      Tags:
+        compare:
+          is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -28,6 +28,8 @@ resources:
           input_fields:
             PolicyName: Name
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/policy/sdk_read_one_post_set_output.go.tpl
       sdk_delete_pre_build_request:
@@ -65,8 +67,13 @@ resources:
         late_initialize: {}
       Path:
         late_initialize: {}
+      Tags:
+        compare:
+          is_ignored: true
   Role:
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/role/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
@@ -107,3 +114,6 @@ resources:
       # calls to manage the set of PolicyARNs attached to this Role.
       Policies:
         type: "[]*string"
+      Tags:
+        compare:
+          is_ignored: true

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -4,11 +4,19 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: ack-iam-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{ else }}
 kind: Role
 metadata:
   creationTimestamp: null
   name: ack-iam-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{ end }}
 rules:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -65,6 +65,14 @@
       ],
       "type": "object"
     },
+    "role": {
+      "description": "Role settings",
+      "properties": {
+        "labels": {
+	  "type": "object"
+	}
+      }
+    },
     "metrics": {
       "description": "Metrics settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,10 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+
+# If "installScope: cluster" then these labels will be applied to ClusterRole
+role:
+ labels: {}
   
 metrics:
   service:

--- a/pkg/resource/policy/delta.go
+++ b/pkg/resource/policy/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
@@ -68,9 +69,6 @@ func newResourceDelta(
 		if *a.ko.Spec.PolicyDocument != *b.ko.Spec.PolicyDocument {
 			delta.Add("Spec.PolicyDocument", a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument)
 		}
-	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/policy/hooks.go
+++ b/pkg/resource/policy/hooks.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	commonutil "github.com/aws-controllers-k8s/iam-controller/pkg/util"
 )
 
 const (
@@ -119,6 +120,22 @@ func (rm *resourceManager) syncTags(
 	}
 
 	return nil
+}
+
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		if !commonutil.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
 }
 
 // inTags returns true if the supplied key and value can be found in the

--- a/pkg/resource/role/delta.go
+++ b/pkg/resource/role/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AssumeRolePolicyDocument, b.ko.Spec.AssumeRolePolicyDocument) {
 		delta.Add("Spec.AssumeRolePolicyDocument", a.ko.Spec.AssumeRolePolicyDocument, b.ko.Spec.AssumeRolePolicyDocument)
@@ -85,9 +86,6 @@ func newResourceDelta(
 	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.Policies, b.ko.Spec.Policies) {
 		delta.Add("Spec.Policies", a.ko.Spec.Policies, b.ko.Spec.Policies)
-	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/util/tags.go
+++ b/pkg/util/tags.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+	svcsdk "github.com/aws/aws-sdk-go/service/iam"
+)
+
+// computeTagsDelta compares two Tag arrays and return two different list
+// containing the addedOrupdated and removed tags. The removed tags array
+// only contains the tags Keys.
+func computeTagsDelta(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
+	var visitedIndexes []string
+mainLoop:
+	for _, aElement := range a {
+		visitedIndexes = append(visitedIndexes, *aElement.Key)
+		for _, bElement := range b {
+			if equalStrings(aElement.Key, bElement.Key) {
+				if !equalStrings(aElement.Value, bElement.Value) {
+					addedOrUpdated = append(addedOrUpdated, bElement)
+				}
+				continue mainLoop
+			}
+		}
+		removed = append(removed, aElement.Key)
+	}
+	for _, bElement := range b {
+		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
+			addedOrUpdated = append(addedOrUpdated, bElement)
+		}
+	}
+	return addedOrUpdated, removed
+}
+
+// EqualTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func EqualTags(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) bool {
+	addedOrUpdated, removed := computeTagsDelta(a, b)
+	return len(addedOrUpdated) == 0 && len(removed) == 0
+}
+
+// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
+// array.
+func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
+}


### PR DESCRIPTION
Lists of Tag structs for both the Role and Policy resources were causing
incorrect Delta differences to be detected when the order of the structs
was different. This brings in some code from the sfn-controller project
to properly ignore differences in only ordering for tags.

Issue aws-controllers-k8s/community#1503

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
