### PR TITLE
Move three custom functions from sdk.go to hooks.go

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-11-01T20:06:26Z"
+  build_date: "2022-11-03T22:02:26Z"
   build_hash: 5ee0ac052c54f008dff50f6f5ebb73f2cf3a0bd7
   go_version: go1.19.2
   version: v0.20.1-4-g5ee0ac0

--- a/pkg/resource/open_id_connect_provider/hooks.go
+++ b/pkg/resource/open_id_connect_provider/hooks.go
@@ -304,3 +304,59 @@ func (rm *resourceManager) removeTags(
 	rm.metrics.RecordAPICall("UPDATE", "UntagOpenIDConnectProvider", err)
 	return err
 }
+
+// returns an SDK-specific struct for the HTTP request
+// payload of the UpdateThumbprint API call for the resource
+func (rm *resourceManager) newUpdateThumbprintRequestPayload(
+	ctx context.Context,
+	r *resource,
+) (*svcsdk.UpdateOpenIDConnectProviderThumbprintInput, error) {
+	res := &svcsdk.UpdateOpenIDConnectProviderThumbprintInput{}
+
+	if r.ko.Spec.Thumbprints != nil {
+		res.SetThumbprintList(*&r.ko.Spec.Thumbprints)
+	}
+	if r.ko.Status.ACKResourceMetadata.ARN != nil {
+		res.SetOpenIDConnectProviderArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	}
+
+	return res, nil
+}
+
+// returns an SDK-specific struct for the HTTP request
+// payload of the AddClientIDToOpenIDConnectProvider API call for the resource
+func (rm *resourceManager) newAddClientIDRequestPayload(
+	ctx context.Context,
+	r *resource,
+	clientId *string,
+) (*svcsdk.AddClientIDToOpenIDConnectProviderInput, error) {
+	res := &svcsdk.AddClientIDToOpenIDConnectProviderInput{}
+
+	if clientId != nil {
+		res.SetClientID(*clientId)
+	}
+	if r.ko.Status.ACKResourceMetadata.ARN != nil {
+		res.SetOpenIDConnectProviderArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	}
+
+	return res, nil
+}
+
+// returns an SDK-specific struct for the HTTP request
+// payload of the RemoveClientIDFromOpenIDConnectProvider API call for the resource
+func (rm *resourceManager) newRemoveClientIDRequestPayload(
+	ctx context.Context,
+	r *resource,
+	clientId *string,
+) (*svcsdk.RemoveClientIDFromOpenIDConnectProviderInput, error) {
+	res := &svcsdk.RemoveClientIDFromOpenIDConnectProviderInput{}
+
+	if clientId != nil {
+		res.SetClientID(*clientId)
+	}
+	if r.ko.Status.ACKResourceMetadata.ARN != nil {
+		res.SetOpenIDConnectProviderArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	}
+
+	return res, nil
+}

--- a/pkg/resource/open_id_connect_provider/sdk.go
+++ b/pkg/resource/open_id_connect_provider/sdk.go
@@ -274,76 +274,8 @@ func (rm *resourceManager) sdkUpdate(
 	desired *resource,
 	latest *resource,
 	delta *ackcompare.Delta,
-) (updated *resource, err error) {
-   return rm.customUpdateOpenIDConnectProvider(ctx, desired, latest, delta)
-}
-
-// getImmutableFieldChanges returns list of immutable fields from the
-func (rm *resourceManager) getImmutableFieldChanges(
-		delta *ackcompare.Delta,
-) []string {
-	var fields []string
-	if delta.DifferentAt("Spec.URL") {
-			fields = append(fields, "URL")
-	}
-
-	return fields
-}
-
-// returns an SDK-specific struct for the HTTP request
-// payload of the UpdateThumbprint API call for the resource
-func (rm *resourceManager) newUpdateThumbprintRequestPayload(
-	ctx context.Context,
-	r *resource,
-) (*svcsdk.UpdateOpenIDConnectProviderThumbprintInput, error) {
-	res := &svcsdk.UpdateOpenIDConnectProviderThumbprintInput{}
-
-	if r.ko.Spec.Thumbprints != nil {
-		res.SetThumbprintList(*&r.ko.Spec.Thumbprints)
-	}
-	if r.ko.Status.ACKResourceMetadata.ARN != nil {
-		res.SetOpenIDConnectProviderArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
-	}
-
-	return res, nil
-}
-
-// returns an SDK-specific struct for the HTTP request
-// payload of the AddClientIDToOpenIDConnectProvider API call for the resource
-func (rm *resourceManager) newAddClientIDRequestPayload(
-	ctx context.Context,
-	r *resource,
-	clientId *string,
-) (*svcsdk.AddClientIDToOpenIDConnectProviderInput, error) {
-	res := &svcsdk.AddClientIDToOpenIDConnectProviderInput{}
-
-	if clientId != nil {
-		res.SetClientID(*clientId)
-	}
-	if r.ko.Status.ACKResourceMetadata.ARN != nil {
-		res.SetOpenIDConnectProviderArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
-	}
-
-	return res, nil
-}
-
-// returns an SDK-specific struct for the HTTP request
-// payload of the RemoveClientIDFromOpenIDConnectProvider API call for the resource
-func (rm *resourceManager) newRemoveClientIDRequestPayload(
-	ctx context.Context,
-	r *resource,
-	clientId *string,
-) (*svcsdk.RemoveClientIDFromOpenIDConnectProviderInput, error) {
-	res := &svcsdk.RemoveClientIDFromOpenIDConnectProviderInput{}
-
-	if clientId != nil {
-		res.SetClientID(*clientId)
-	}
-	if r.ko.Status.ACKResourceMetadata.ARN != nil {
-		res.SetOpenIDConnectProviderArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
-	}
-
-	return res, nil
+) (*resource, error) {
+	return rm.customUpdateOpenIDConnectProvider(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API
@@ -494,4 +426,16 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// getImmutableFieldChanges returns list of immutable fields from the
+func (rm *resourceManager) getImmutableFieldChanges(
+	delta *ackcompare.Delta,
+) []string {
+	var fields []string
+	if delta.DifferentAt("Spec.Url") {
+		fields = append(fields, "Url")
+	}
+
+	return fields
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Following up on #43 , move 3 custom functions out of `sdk.go` and into `hooks.go` so that code generation doesn't clobber the contents in the former.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
