### PR TITLE
Add hooks to set `User` and `Group` paths in their update requests

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-11-04T22:54:04Z"
+  build_date: "2022-11-07T20:21:57Z"
   build_hash: 18745aa8d1126566776a4748c403ae891b889e9c
   go_version: go1.18.3
   version: v0.20.1-7-g18745aa
@@ -7,7 +7,7 @@ api_directory_checksum: b9831e30d09efac2329a13759a2c779ac2bac4d6
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 25917ff789e0e573053a1b7b507c21acfb91c527
+  file_checksum: 6fd6708dff329c27d9f9468af2d60d80af7cfc13
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -27,6 +27,8 @@ resources:
         template_path: hooks/group/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/group/sdk_create_post_set_output.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/group/sdk_update_post_build_request.go.tpl
       sdk_update_post_set_output:
         template_path: hooks/group/sdk_update_post_set_output.go.tpl
       sdk_delete_pre_build_request:
@@ -199,6 +201,8 @@ resources:
         template_path: hooks/user/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/user/sdk_create_post_set_output.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/user/sdk_update_post_build_request.go.tpl
       sdk_update_post_set_output:
         template_path: hooks/user/sdk_update_post_set_output.go.tpl
       sdk_delete_pre_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -27,6 +27,8 @@ resources:
         template_path: hooks/group/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/group/sdk_create_post_set_output.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/group/sdk_update_post_build_request.go.tpl
       sdk_update_post_set_output:
         template_path: hooks/group/sdk_update_post_set_output.go.tpl
       sdk_delete_pre_build_request:
@@ -199,6 +201,8 @@ resources:
         template_path: hooks/user/sdk_read_one_post_set_output.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/user/sdk_create_post_set_output.go.tpl
+      sdk_update_post_build_request:
+        template_path: hooks/user/sdk_update_post_build_request.go.tpl
       sdk_update_post_set_output:
         template_path: hooks/user/sdk_update_post_set_output.go.tpl
       sdk_delete_pre_build_request:

--- a/pkg/resource/group/sdk.go
+++ b/pkg/resource/group/sdk.go
@@ -248,6 +248,17 @@ func (rm *resourceManager) sdkUpdate(
 	if err != nil {
 		return nil, err
 	}
+	// The code-generator expect the SDK field and the CR field to have
+	// exact matching names. Which is not the case for `Path` (CR field)
+	// and `NewPath` (SDK field). It is currently possible to set a CR
+	// field from a custom field but the other way around. For now we
+	// set those manually and wait for a better solution.
+	//
+	// TODO(A-Hilaly): remove once aws-controllers-k8s/community#1532
+	// or better idea is implemented
+	if desired.ko.Spec.Path != nil {
+		input.NewPath = desired.ko.Spec.Path
+	}
 
 	var resp *svcsdk.UpdateGroupOutput
 	_ = resp

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -321,6 +321,17 @@ func (rm *resourceManager) sdkUpdate(
 	if err != nil {
 		return nil, err
 	}
+	// The code-generator expect the SDK field and the CR field to have
+	// exact matching names. Which is not the case for `Path` (CR field)
+	// and `NewPath` (SDK field). It is currently possible to set a CR
+	// field from a custom field but the other way around. For now we
+	// set those manually and wait for a better solution.
+	//
+	// TODO(A-Hilaly): remove once aws-controllers-k8s/community#1532
+	// or better idea is implemented
+	if desired.ko.Spec.Path != nil {
+		input.NewPath = desired.ko.Spec.Path
+	}
 
 	var resp *svcsdk.UpdateUserOutput
 	_ = resp

--- a/templates/hooks/group/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/group/sdk_update_post_build_request.go.tpl
@@ -1,0 +1,11 @@
+    // The code-generator expect the SDK field and the CR field to have
+    // exact matching names. Which is not the case for `Path` (CR field)
+    // and `NewPath` (SDK field). It is currently possible to set a CR
+    // field from a custom field but the other way around. For now we
+    // set those manually and wait for a better solution.
+    // 
+    // TODO(A-Hilaly): remove once aws-controllers-k8s/community#1532
+    // or better idea is implemented
+    if desired.ko.Spec.Path != nil {
+        input.NewPath = desired.ko.Spec.Path
+    }

--- a/templates/hooks/user/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/user/sdk_update_post_build_request.go.tpl
@@ -1,0 +1,11 @@
+    // The code-generator expect the SDK field and the CR field to have
+    // exact matching names. Which is not the case for `Path` (CR field)
+    // and `NewPath` (SDK field). It is currently possible to set a CR
+    // field from a custom field but the other way around. For now we
+    // set those manually and wait for a better solution.
+    // 
+    // TODO(A-Hilaly): remove once aws-controllers-k8s/community#1532
+    // or better idea is implemented
+    if desired.ko.Spec.Path != nil {
+        input.NewPath = desired.ko.Spec.Path
+    }

--- a/test/e2e/tests/test_group.py
+++ b/test/e2e/tests/test_group.py
@@ -68,14 +68,21 @@ class TestGroup:
         policy_arns = [
             "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
         ]
+        new_path = "/engineering/"
         updates = {
-            "spec": {"policies": policy_arns},
+            "spec": {
+                "policies": policy_arns,
+                "path": new_path,
+            },
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         latest_policy_arns = group.get_attached_policy_arns(group_name)
         assert latest_policy_arns == policy_arns
+
+        latest_group = group.get(group_name)
+        assert latest_group["Path"] == new_path
 
         k8s.delete_custom_resource(ref)
 

--- a/test/e2e/tests/test_user.py
+++ b/test/e2e/tests/test_user.py
@@ -70,14 +70,21 @@ class TestUser:
         policy_arns = [
             "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
         ]
+        new_path = "/engineering/"
         updates = {
-            "spec": {"policies": policy_arns},
+            "spec": {
+                "policies": policy_arns,
+                "path": new_path,
+            },
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         latest_policy_arns = user.get_attached_policy_arns(user_name)
         assert latest_policy_arns == policy_arns
+
+        latest_user = user.get(user_name)
+        assert latest_user["Path"] == new_path
 
         # Same update code path check for tags...
         latest_tags = user.get_tags(user_name)


### PR DESCRIPTION
The code-generator isn't able to generate correct code for
`newUpdateRequestPayload`. More specifically it doesn't set the
`spec.path` to `input.NewPath`. The reason is that the code-generator
expects the SDK field and CR field names to be similar.

Currently we have a feature that allows the code-generator to set a
field from a different SDK field name. But not the other way around.

We can discuss the above in https://github.com/aws-controllers-k8s/community/issues/1532

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
