### PR TITLE
Support `User` and `Role` permissions boundary updates

### DIFF
--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -405,6 +405,11 @@ func (rm *resourceManager) sdkUpdate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
+	if delta.DifferentAt("Spec.PermissionsBoundary") {
+		if err := rm.syncRolePermissionsBoundary(ctx, &resource{ko}); err != nil {
+			return nil, err
+		}
+	}
 	if err := rm.syncPolicies(ctx, &resource{ko}); err != nil {
 		return nil, err
 	}

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -345,6 +345,11 @@ func (rm *resourceManager) sdkUpdate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
+	if delta.DifferentAt("Spec.PermissionsBoundary") {
+		if err := rm.syncUserPermissionsBoundary(ctx, &resource{ko}); err != nil {
+			return nil, err
+		}
+	}
 	if delta.DifferentAt("Spec.Policies") {
 		if err := rm.syncPolicies(ctx, &resource{ko}); err != nil {
 			return nil, err

--- a/templates/hooks/role/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_update_post_set_output.go.tpl
@@ -1,3 +1,8 @@
+    if delta.DifferentAt("Spec.PermissionsBoundary") {
+        if err := rm.syncRolePermissionsBoundary(ctx, &resource{ko}); err != nil {
+            return nil, err
+        }
+    }
     if err := rm.syncPolicies(ctx, &resource{ko}); err != nil {
         return nil, err
     }

--- a/templates/hooks/user/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/user/sdk_update_post_set_output.go.tpl
@@ -1,3 +1,8 @@
+    if delta.DifferentAt("Spec.PermissionsBoundary") {
+        if err := rm.syncUserPermissionsBoundary(ctx, &resource{ko}); err != nil {
+            return nil, err
+        }
+    }
     if delta.DifferentAt("Spec.Policies") {
         if err := rm.syncPolicies(ctx, &resource{ko}); err != nil {
             return nil, err

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -95,14 +95,21 @@ class TestRole:
         policy_arns = [
             "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
         ]
+        permissionsBoundary = 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'
         updates = {
-            "spec": {"policies": policy_arns},
+            "spec": {
+                "policies": policy_arns,
+                "permissionsBoundary": permissionsBoundary,
+            },
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-
+        
         latest_policy_arns = role.get_attached_policy_arns(role_name)
         assert latest_policy_arns == policy_arns
+
+        latest_role = role.get(role_name)
+        assert latest_role["PermissionsBoundary"]["PermissionsBoundaryArn"] == permissionsBoundary
 
         # Same update code path check for tags...
         latest_tags = role.get_tags(role_name)

--- a/test/e2e/tests/test_user.py
+++ b/test/e2e/tests/test_user.py
@@ -70,11 +70,13 @@ class TestUser:
         policy_arns = [
             "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
         ]
+        permissionsBoundary = 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'
         new_path = "/engineering/"
         updates = {
             "spec": {
                 "policies": policy_arns,
                 "path": new_path,
+                "permissionsBoundary": permissionsBoundary,
             },
         }
         k8s.patch_custom_resource(ref, updates)
@@ -85,6 +87,7 @@ class TestUser:
 
         latest_user = user.get(user_name)
         assert latest_user["Path"] == new_path
+        assert latest_user["PermissionsBoundary"]["PermissionsBoundaryArn"] == permissionsBoundary
 
         # Same update code path check for tags...
         latest_tags = user.get_tags(user_name)


### PR DESCRIPTION
Currently the update code path for `Users` and `Role` doesn't support
updates for permissionBoundary field. This patch adds the necessary
hooks and helper functions to help with that.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
