### PR TITLE
Add `iam:PutUserPermissionsBoundary` to `recommended-inline-policy`

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -14,6 +14,7 @@
                 "iam:DeleteRole",
                 "iam:UpdateRole",
                 "iam:PutRolePermissionsBoundary",
+                "iam:PutUserPermissionsBoundary",
                 "iam:GetUser",
                 "iam:CreateUser",
                 "iam:DeleteUser",


### PR DESCRIPTION
This policy is needed to satisfy the current e2e test @ `TestUser::test_crud`

Description of changes:
Following up on https://github.com/aws-controllers-k8s/iam-controller/pull/47, we need to add PutUserPermissionsBoundary to the list of recommended policies that the controller should have.

Ran into this error when trying to run e2e tests; specifically, TestUser::test_crud was failing; examining the logs of the iam-controller pod being run revealed a 403 error complaining that the assumed role did not have the right to perform this action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
