### PR TITLE
add resource reference e2e test

### DIFF
--- a/test/e2e/resources/role_referring.yaml
+++ b/test/e2e/resources/role_referring.yaml
@@ -1,0 +1,24 @@
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Role
+metadata:
+  name: $ROLE_NAME
+spec:
+  name: $ROLE_NAME
+  description: "a role that refers to a policy"
+  maxSessionDuration: 3600
+  assumeRolePolicyDocument: >
+    {
+      "Version":"2012-10-17",
+      "Statement": [{
+        "Effect":"Allow",
+        "Principal": {
+          "Service": [
+            "ec2.amazonaws.com"
+          ]
+        },
+        "Action": ["sts:AssumeRole"]
+      }]
+    }
+  policyRefs:
+    - from:
+        name: $POLICY_NAME

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -1,0 +1,157 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for resource references"""
+
+import json
+import time
+
+import pytest
+
+from acktest.k8s import condition
+from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
+from e2e.common.types import POLICY_RESOURCE_PLURAL, ROLE_RESOURCE_PLURAL
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import role
+from e2e import policy
+from e2e import tag
+
+DELETE_ROLE_TIMEOUT_SECONDS = 10
+# Little longer to delete the policy since it's referred-to from the role...
+DELETE_POLICY_TIMEOUT_SECONDS = 30
+CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS = 10
+
+@pytest.fixture(scope="module")
+def referred_policy_name():
+    return random_suffix_name("referred-policy", 24)
+
+
+@pytest.fixture(scope="module")
+def referring_role(referred_policy_name):
+    role_name = random_suffix_name("referring-role", 24)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements['ROLE_NAME'] = role_name
+    replacements['POLICY_NAME'] = referred_policy_name
+
+    resource_data = load_resource(
+        "role_referring",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, ROLE_RESOURCE_PLURAL,
+        role_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    # NOTE(jaypipes): We specifically do NOT wait for the Role to exist in
+    # the IAM API here because we will create the referred-to Policy and
+    # wait for the reference to be resolved
+
+    yield (ref, cr, role_name)
+
+    if k8s.get_resource_exists(ref):
+        # If all goes properly, we should not hit this because the test cleans
+        # up the child resource before exiting...
+        _, deleted = k8s.delete_custom_resource(
+            ref,
+            period_length=DELETE_ROLE_TIMEOUT_SECONDS,
+        )
+        assert deleted
+
+        role.wait_until_deleted(role_name)
+
+
+@pytest.fixture(scope="module")
+def referred_policy(referred_policy_name):
+    policy_desc = "a referred-to policy"
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements['POLICY_NAME'] = referred_policy_name
+    replacements['POLICY_DESCRIPTION'] = policy_desc
+
+    resource_data = load_resource(
+        "policy_simple",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, POLICY_RESOURCE_PLURAL,
+        referred_policy_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    cr = k8s.get_resource(ref)
+    assert cr is not None
+    assert 'status' in cr
+    assert 'ackResourceMetadata' in cr['status']
+    assert 'arn' in cr['status']['ackResourceMetadata']
+    policy_arn = cr['status']['ackResourceMetadata']['arn']
+
+    policy.wait_until_exists(policy_arn)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr, policy_arn)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_POLICY_TIMEOUT_SECONDS,
+    )
+    assert deleted
+
+    policy.wait_until_deleted(policy_arn)
+
+
+@service_marker
+@pytest.mark.canary
+class TestReferences:
+    def test_role_policy_references(self, referring_role, referred_policy):
+
+        # create the resources in order that initially the reference resolution
+        # fails and then when the referenced resource gets created, then all
+        # resolutions eventually pass and resources get synced.
+        role_ref, role_cr, role_name = referring_role
+
+        time.sleep(1)
+
+        policy_ref, policy_cr, policy_arn = referred_policy
+
+        time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
+
+        condition.assert_synced(policy_ref)
+        condition.assert_synced(role_ref)
+
+        role.wait_until_exists(role_name)
+
+        # NOTE(jaypipes): We need to manually delete the Role first because
+        # pytest fixtures will try to clean up the Policy fixture *first*
+        # (because it was initialized after Role) but if we try to delete the
+        # Role before the Policy, the cascading delete protection of resource
+        # references will mean the Role won't be deleted.
+        _, deleted = k8s.delete_custom_resource(
+            role_ref,
+            period_length=DELETE_ROLE_TIMEOUT_SECONDS,
+        )
+        assert deleted
+
+        role.wait_until_deleted(role_name)


### PR DESCRIPTION
Adds an e2e test that verifies resource references (at least from Role -> Policy) are working as expected.

Issue aws-controllers-k8s/community#1610

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
