### PR TITLE
support Role.inlinePolicies

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-02-09T23:19:12Z"
+  build_date: "2023-02-28T16:33:37Z"
   build_hash: d0f3d78cbea8061f822cbceac3786128f091efe6
-  go_version: go1.19
+  go_version: go1.19.4
   version: v0.24.2
-api_directory_checksum: 60fd1a041f3afbd8679e290fe8ae14de1cde18c0
+api_directory_checksum: 68b20a583916eac0fb007442dfd1220a9fb9722d
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: b07049b26227228868e9341be9b2b065eacf247b
+  file_checksum: 52f2fa89ae0904d8c6d22fafaa472d1943b23211
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -169,6 +169,15 @@ resources:
         references:
           resource: Policy
           path: Status.ACKResourceMetadata.ARN
+      # These are policy documents that are added to the Role using the
+      # Put/DeleteRolePolicy APIs, as compared to the Attach/DetachRolePolicy
+      # APIs that are for non-inline managed policies.
+      #
+      # The map key is the PolicyDocumentName and the map value is the JSON
+      # policy document.
+      InlinePolicies:
+        type: map[string]*string
+        late_initialize: {}
       Tags:
         compare:
           is_ignored: true

--- a/apis/v1alpha1/role.go
+++ b/apis/v1alpha1/role.go
@@ -50,7 +50,8 @@ type RoleSpec struct {
 	// +kubebuilder:validation:Required
 	AssumeRolePolicyDocument *string `json:"assumeRolePolicyDocument"`
 	// A description of the role.
-	Description *string `json:"description,omitempty"`
+	Description    *string            `json:"description,omitempty"`
+	InlinePolicies map[string]*string `json:"inlinePolicies,omitempty"`
 	// The maximum session duration (in seconds) that you want to set for the specified
 	// role. If you do not specify a value for this setting, the default value of
 	// one hour is applied. This setting can have a value from 1 hour to 12 hours.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1472,6 +1472,21 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.InlinePolicies != nil {
+		in, out := &in.InlinePolicies, &out.InlinePolicies
+		*out = make(map[string]*string, len(*in))
+		for key, val := range *in {
+			var outVal *string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(string)
+				**out = **in
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.MaxSessionDuration != nil {
 		in, out := &in.MaxSessionDuration, &out.MaxSessionDuration
 		*out = new(int64)

--- a/config/crd/bases/iam.services.k8s.aws_roles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_roles.yaml
@@ -56,6 +56,10 @@ spec:
               description:
                 description: A description of the role.
                 type: string
+              inlinePolicies:
+                additionalProperties:
+                  type: string
+                type: object
               maxSessionDuration:
                 description: "The maximum session duration (in seconds) that you want
                   to set for the specified role. If you do not specify a value for

--- a/generator.yaml
+++ b/generator.yaml
@@ -169,6 +169,14 @@ resources:
         references:
           resource: Policy
           path: Status.ACKResourceMetadata.ARN
+      # These are policy documents that are added to the Role using the
+      # Put/DeleteRolePolicy APIs, as compared to the Attach/DetachRolePolicy
+      # APIs that are for non-inline managed policies.
+      #
+      # The map key is the PolicyDocumentName and the map value is the JSON
+      # policy document.
+      InlinePolicies:
+        type: map[string]*string
       Tags:
         compare:
           is_ignored: true

--- a/helm/crds/iam.services.k8s.aws_roles.yaml
+++ b/helm/crds/iam.services.k8s.aws_roles.yaml
@@ -56,6 +56,10 @@ spec:
               description:
                 description: A description of the role.
                 type: string
+              inlinePolicies:
+                additionalProperties:
+                  type: string
+                type: object
               maxSessionDuration:
                 description: "The maximum session duration (in seconds) that you want
                   to set for the specified role. If you do not specify a value for

--- a/pkg/resource/role/delta.go
+++ b/pkg/resource/role/delta.go
@@ -58,6 +58,13 @@ func newResourceDelta(
 			delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.InlinePolicies, b.ko.Spec.InlinePolicies) {
+		delta.Add("Spec.InlinePolicies", a.ko.Spec.InlinePolicies, b.ko.Spec.InlinePolicies)
+	} else if a.ko.Spec.InlinePolicies != nil && b.ko.Spec.InlinePolicies != nil {
+		if !ackcompare.MapStringStringPEqual(a.ko.Spec.InlinePolicies, b.ko.Spec.InlinePolicies) {
+			delta.Add("Spec.InlinePolicies", a.ko.Spec.InlinePolicies, b.ko.Spec.InlinePolicies)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MaxSessionDuration, b.ko.Spec.MaxSessionDuration) {
 		delta.Add("Spec.MaxSessionDuration", a.ko.Spec.MaxSessionDuration, b.ko.Spec.MaxSessionDuration)
 	} else if a.ko.Spec.MaxSessionDuration != nil && b.ko.Spec.MaxSessionDuration != nil {

--- a/pkg/resource/role/manager.go
+++ b/pkg/resource/role/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"MaxSessionDuration", "Path"}
+var lateInitializeFieldNames = []string{"InlinePolicies", "MaxSessionDuration", "Path"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -249,6 +249,9 @@ func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.InlinePolicies == nil {
+		return true
+	}
 	if ko.Spec.MaxSessionDuration == nil {
 		return true
 	}
@@ -266,6 +269,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 ) acktypes.AWSResource {
 	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.InlinePolicies != nil && latestKo.Spec.InlinePolicies == nil {
+		latestKo.Spec.InlinePolicies = observedKo.Spec.InlinePolicies
+	}
 	if observedKo.Spec.MaxSessionDuration != nil && latestKo.Spec.MaxSessionDuration == nil {
 		latestKo.Spec.MaxSessionDuration = observedKo.Spec.MaxSessionDuration
 	}

--- a/templates/hooks/role/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_create_post_set_output.go.tpl
@@ -1,5 +1,5 @@
     if ko.Spec.AssumeRolePolicyDocument != nil {
-		if doc, err := decodeAssumeDocument(*ko.Spec.AssumeRolePolicyDocument); err != nil {
+		if doc, err := decodeDocument(*ko.Spec.AssumeRolePolicyDocument); err != nil {
 			return nil, err
 		} else {
 			ko.Spec.AssumeRolePolicyDocument = &doc

--- a/templates/hooks/role/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/role/sdk_delete_pre_build_request.go.tpl
@@ -1,6 +1,10 @@
-	// This causes syncPolicies to delete all associated policies from the role
+	// This deletes all associated managed and inline policies from the role
 	roleCpy := r.ko.DeepCopy()
 	roleCpy.Spec.Policies = nil
-	if err := rm.syncPolicies(ctx, &resource{ko: roleCpy}, r); err != nil {
+	if err := rm.syncManagedPolicies(ctx, &resource{ko: roleCpy}, r); err != nil {
+		return nil, err
+	}
+	roleCpy.Spec.InlinePolicies = map[string]*string{}
+	if err := rm.syncInlinePolicies(ctx, &resource{ko: roleCpy}, r); err != nil {
 		return nil, err
 	}

--- a/templates/hooks/role/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_read_one_post_set_output.go.tpl
@@ -1,11 +1,15 @@
 	if ko.Spec.AssumeRolePolicyDocument != nil {
-		if doc, err := decodeAssumeDocument(*ko.Spec.AssumeRolePolicyDocument); err != nil {
+		if doc, err := decodeDocument(*ko.Spec.AssumeRolePolicyDocument); err != nil {
 			return nil, err
 		} else {
 			ko.Spec.AssumeRolePolicyDocument = &doc
 		}
 	}
-	ko.Spec.Policies, err = rm.getPolicies(ctx, &resource{ko})
+	ko.Spec.Policies, err = rm.getManagedPolicies(ctx, &resource{ko})
+	if err != nil {
+		return nil, err
+	}
+	ko.Spec.InlinePolicies, err = rm.getInlinePolicies(ctx, &resource{ko})
 	if err != nil {
 		return nil, err
 	}

--- a/templates/hooks/role/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/role/sdk_update_pre_build_request.go.tpl
@@ -1,5 +1,11 @@
 	if delta.DifferentAt("Spec.Policies") {
-		err = rm.syncPolicies(ctx, desired, latest)
+		err = rm.syncManagedPolicies(ctx, desired, latest)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if delta.DifferentAt("Spec.InlinePolicies") {
+		err = rm.syncInlinePolicies(ctx, desired, latest)
 		if err != nil {
 			return nil, err
 		}
@@ -16,6 +22,6 @@
 			return nil, err
 		}
 	}
-	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.PermissionsBoundary") {
+	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary") {
 		return desired, nil
 	}


### PR DESCRIPTION
Adds support for inline policies for Role resources.

The new `Role.Spec.inlinePolicies` field is a `map[string]*string`, keyed by the inline policy *name* and valued with the inline policy *document* (serialized JSON string).

Inline policies are actually added and removed from a Role using different IAM API calls than their *managed policy* counterparts. Whereas managed policies (contained in the `Role.Spec.Policies` field) are attached and detached from the Role using the `AttachPolicyRole` and `DetachRolePolicy` API calls, the inline policies are attached and detached from the Role using the `AddRolePolicy` and `DeleteRolePolicy` API calls. Yes, this is confusing and why I hadn't actually included inline policies from the very beginning (I did not realize these were separate things and separate API calls).

Similar to managed policies, all inline policies are removed from the Role prior to role deletion.

Issue aws-controllers-k8s/community#1644

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
