### PR TITLE
ensure comparing maps of strings not pointers

### DIFF
--- a/pkg/resource/group/hooks.go
+++ b/pkg/resource/group/hooks.go
@@ -21,6 +21,8 @@ import (
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/iam"
 	"github.com/samber/lo"
+
+	commonutil "github.com/aws-controllers-k8s/iam-controller/pkg/util"
 )
 
 // syncManagedPolicies examines the managed PolicyARNs in the supplied Group
@@ -153,8 +155,12 @@ func (rm *resourceManager) syncInlinePolicies(
 
 	existingPolicies := latest.ko.Spec.InlinePolicies
 
-	existingPairs := lo.ToPairs(existingPolicies)
-	desiredPairs := lo.ToPairs(desired.ko.Spec.InlinePolicies)
+	existingPairs := lo.ToPairs(
+		commonutil.MapStringFromMapStringPointers(existingPolicies),
+	)
+	desiredPairs := lo.ToPairs(
+		commonutil.MapStringFromMapStringPointers(desired.ko.Spec.InlinePolicies),
+	)
 
 	toDelete, toAdd := lo.Difference(existingPairs, desiredPairs)
 
@@ -165,7 +171,7 @@ func (rm *resourceManager) syncInlinePolicies(
 			"adding inline policy to group",
 			"policy_name", polName,
 		)
-		err = rm.addInlinePolicy(ctx, desired, polName, polDoc)
+		err = rm.addInlinePolicy(ctx, desired, polName, &polDoc)
 		if err != nil {
 			return err
 		}

--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -205,8 +205,12 @@ func (rm *resourceManager) syncInlinePolicies(
 
 	existingPolicies := latest.ko.Spec.InlinePolicies
 
-	existingPairs := lo.ToPairs(existingPolicies)
-	desiredPairs := lo.ToPairs(desired.ko.Spec.InlinePolicies)
+	existingPairs := lo.ToPairs(
+		commonutil.MapStringFromMapStringPointers(existingPolicies),
+	)
+	desiredPairs := lo.ToPairs(
+		commonutil.MapStringFromMapStringPointers(desired.ko.Spec.InlinePolicies),
+	)
 
 	toDelete, toAdd := lo.Difference(existingPairs, desiredPairs)
 
@@ -217,7 +221,7 @@ func (rm *resourceManager) syncInlinePolicies(
 			"adding inline policy to role",
 			"policy_name", polName,
 		)
-		err = rm.addInlinePolicy(ctx, desired, polName, polDoc)
+		err = rm.addInlinePolicy(ctx, desired, polName, &polDoc)
 		if err != nil {
 			return err
 		}

--- a/pkg/resource/user/hooks.go
+++ b/pkg/resource/user/hooks.go
@@ -212,8 +212,12 @@ func (rm *resourceManager) syncInlinePolicies(
 
 	existingPolicies := latest.ko.Spec.InlinePolicies
 
-	existingPairs := lo.ToPairs(existingPolicies)
-	desiredPairs := lo.ToPairs(desired.ko.Spec.InlinePolicies)
+	existingPairs := lo.ToPairs(
+		commonutil.MapStringFromMapStringPointers(existingPolicies),
+	)
+	desiredPairs := lo.ToPairs(
+		commonutil.MapStringFromMapStringPointers(desired.ko.Spec.InlinePolicies),
+	)
 
 	toDelete, toAdd := lo.Difference(existingPairs, desiredPairs)
 
@@ -224,7 +228,7 @@ func (rm *resourceManager) syncInlinePolicies(
 			"adding inline policy to user",
 			"policy_name", polName,
 		)
-		err = rm.addInlinePolicy(ctx, desired, polName, polDoc)
+		err = rm.addInlinePolicy(ctx, desired, polName, &polDoc)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/map.go
+++ b/pkg/util/map.go
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+// MapStringFromMapStringPointers takes a map[string]*string and returns a
+// map[string]string
+func MapStringFromMapStringPointers(
+	subject map[string]*string,
+) map[string]string {
+	result := map[string]string{}
+	for k, v := range subject {
+		result[k] = *v
+	}
+	return result
+}


### PR DESCRIPTION
For the inline policies, I used `github.com/samber/lo.Difference` function to compare two sets of k/v pairs. Unfortunately, I forgot to dereference the `*string` values of the inline policy `map[string]*string` into a `map[string]string` before doing so, which meant that the `lo.Difference` function was comparing against pointer values.

Fixes issue aws-controllers-k8s/community#1735

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
