### PR TITLE
Enable leader election options for iam controller

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
@@ -64,6 +64,9 @@ spec:
         - --reconcile-resource-resync-seconds
         - "$(RECONCILE_RESOURCE_RESYNC_SECONDS_{{ $key | upper }})"
 {{- end }}
+        {{- if (gt .Values.deployment.replicas 1.0) }}
+        - --enable-leader-election
+        {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -58,6 +58,11 @@
         },
         "priorityClassName": {
           "type": "string"
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3
         }
       },
       "required": [

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,6 +12,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 deployment:
+  replicas: 2
   annotations: {}
   labels: {}
   containerPort: 8080


### PR DESCRIPTION
Issue #, if available:

Fixes https://github.com/aws-controllers-k8s/community/issues/1753

Description of changes:

- Add `.Values.deployment.replicas` to allow multiple replicas to be run
- Add `--enable-leader-election` flag if the above flag is set to `> 1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
