### PR TITLE
feat: sync assume role policy document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-04-03T11:31:59Z"
+  build_date: "2023-04-03T14:40:28Z"
   build_hash: a6ae2078e57187b2daf47978bc07bd67072d2cba
   go_version: go1.19.6
   version: v0.25.0-1-ga6ae207

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2023-03-22T22:04:22Z"
-  build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
-  go_version: go1.19
-  version: v0.25.0
+  build_date: "2023-04-03T11:31:59Z"
+  build_hash: a6ae2078e57187b2daf47978bc07bd67072d2cba
+  go_version: go1.19.6
+  version: v0.25.0-1-ga6ae207
 api_directory_checksum: 26341f700d12dfcd4033cf4203492fa381daa7b0
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93

--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -364,7 +364,7 @@ func (rm *resourceManager) putAssumeRolePolicies(
 	defer func() { exit(err) }()
 
 	input := &svcsdk.UpdateAssumeRolePolicyInput{
-		RoleName:       &r.ko.ObjectMeta.Name, // Name of the role is the name of the K8s object.
+		RoleName:       r.ko.Spec.Name,
 		PolicyDocument: r.ko.Spec.AssumeRolePolicyDocument,
 	}
 	_, err = rm.sdkapi.UpdateAssumeRolePolicyWithContext(ctx, input)

--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -342,25 +342,14 @@ func (rm *resourceManager) removeInlinePolicy(
 	return err
 }
 
-// syncAssumeRolePolicies syncs the role's assume role policy document.
-func (rm *resourceManager) syncAssumeRolePolicies(
-	ctx context.Context,
-	r *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncAssumeRolePolicies")
-	defer func() { exit(err) }()
-	return rm.putAssumeRolePolicies(ctx, r)
-}
-
 // putAssumeRolePolicies calls the IAM API to set a given role's
 // assume role policy document.
-func (rm *resourceManager) putAssumeRolePolicies(
+func (rm *resourceManager) putAssumeRolePolicy(
 	ctx context.Context,
 	r *resource,
 ) (err error) {
 	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.putAssumeRolePolicies")
+	exit := rlog.Trace("rm.putAssumeRolePolicy")
 	defer func() { exit(err) }()
 
 	input := &svcsdk.UpdateAssumeRolePolicyInput{

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -412,6 +412,14 @@ func (rm *resourceManager) sdkUpdate(
 			return nil, err
 		}
 	}
+
+	if delta.DifferentAt("Spec.AssumeRolePolicyDocument") {
+		err = rm.syncAssumeRolePolicies(ctx, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary") {
 		return desired, nil
 	}

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -420,7 +420,7 @@ func (rm *resourceManager) sdkUpdate(
 		}
 	}
 
-	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary") {
+	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary", "Spec.AssumeRolePolicyDocument") {
 		return desired, nil
 	}
 

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -413,14 +413,7 @@ func (rm *resourceManager) sdkUpdate(
 		}
 	}
 
-	if delta.DifferentAt("Spec.AssumeRolePolicyDocument") {
-		err = rm.syncAssumeRolePolicies(ctx, desired)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary", "Spec.AssumeRolePolicyDocument") {
+	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary") {
 		return desired, nil
 	}
 

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -413,7 +413,7 @@ func (rm *resourceManager) sdkUpdate(
 		}
 	}
 	if delta.DifferentAt("Spec.AssumeRolePolicyDocument") {
-		err = rm.syncAssumeRolePolicies(ctx, desired)
+		err = rm.putAssumeRolePolicy(ctx, desired)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -412,8 +412,13 @@ func (rm *resourceManager) sdkUpdate(
 			return nil, err
 		}
 	}
-
-	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary") {
+	if delta.DifferentAt("Spec.AssumeRolePolicyDocument") {
+		err = rm.syncAssumeRolePolicies(ctx, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary", "Spec.AssumeRolePolicyDocument") {
 		return desired, nil
 	}
 

--- a/templates/hooks/role/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/role/sdk_update_pre_build_request.go.tpl
@@ -23,7 +23,7 @@
 		}
 	}
 	if delta.DifferentAt("Spec.AssumeRolePolicyDocument") {
-		err = rm.syncAssumeRolePolicies(ctx, desired)
+		err = rm.putAssumeRolePolicy(ctx, desired)
 		if err != nil {
 			return nil, err
 		}

--- a/templates/hooks/role/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/role/sdk_update_pre_build_request.go.tpl
@@ -22,6 +22,12 @@
 			return nil, err
 		}
 	}
-	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary") {
+	if delta.DifferentAt("Spec.AssumeRolePolicyDocument") {
+		err = rm.syncAssumeRolePolicies(ctx, desired)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags", "Spec.Policies", "Spec.InlinePolicies", "Spec.PermissionsBoundary", "Spec.AssumeRolePolicyDocument") {
 		return desired, nil
 	}

--- a/test/e2e/role.py
+++ b/test/e2e/role.py
@@ -149,3 +149,16 @@ def get_inline_policies(role_name):
         return policies
     except c.exceptions.NoSuchEntityException:
         return None
+
+def get_assume_role_policy(role_name):
+    """Returns a dict representing the assume role policy document for the supplied Role.
+
+    If no such Role exists, returns None.
+    """
+    c = boto3.client('iam')
+    try:
+        resp = get(role_name)
+        return resp['AssumeRolePolicyDocument']
+    except c.exceptions.NoSuchEntityException:
+        return None
+

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -219,14 +219,9 @@ class TestRole:
         latest_inline_policies = role.get_inline_policies(role_name)
         assert len(latest_inline_policies) == 0
 
+        # AssumeRolePolicyDocument tests
 
-        # assumeRolePolicyDocument tests:
-        # Assert that the policy is as expected.
-        # Modify it.
-        # Delete it
-
-        assume_role_policy_doc = '''
-{
+        assume_role_policy_doc = '''{
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -236,9 +231,7 @@ class TestRole:
             },
             "Action": ["sts:AssumeRole"]
         }
-    ]
-}
-'''
+    ]}'''
 
         cr = k8s.get_resource(ref)
         assert cr is not None
@@ -249,8 +242,7 @@ class TestRole:
         k8s_assume_role_policy = json.loads(cr['spec']['assumeRolePolicyDocument'])
         assert assume_role_policy_as_obj == k8s_assume_role_policy
 
-        assume_role_policy_to_deny_doc = '''
-{
+        assume_role_policy_to_deny_doc = '''{
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -260,9 +252,7 @@ class TestRole:
             },
             "Action": ["sts:AssumeRole"]
         }
-    ]
-}
-'''
+    ]}'''
 
         updates = {
             'spec': {

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -231,9 +231,9 @@ class TestRole:
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": [
-                "Service": "ec2.amazonaws.com"
-            ],
+            "Principal": {
+                "Service": ["ec2.amazonaws.com"]
+            },
             "Action": ["sts:AssumeRole"]
         }
     ]
@@ -255,9 +255,9 @@ class TestRole:
     "Statement": [
         {
             "Effect": "Deny",
-            "Principal": [
-                "Service": "ec2.amazonaws.com"
-            ],
+            "Principal": {
+                "Service": ["ec2.amazonaws.com"]
+            },
             "Action": ["sts:AssumeRole"]
         }
     ]
@@ -282,8 +282,10 @@ class TestRole:
         k8s_assume_role_policy_deny = json.loads(cr['spec']['assumeRolePolicyDocument'])
         assert assume_role_policy_deny_obj == k8s_assume_role_policy_deny
 
+        # AWS slightly modifies the JSON structure underneath us here, so the documents
+        # are not identical. Instead, we can ensure that the change we made is reflected.
         latest_assume_role_policy_doc = role.get_assume_role_policy(role_name)
-        assert latest_assume_role_policy_doc == k8s_assume_role_policy_deny
+        assert latest_assume_role_policy_doc['Statement'][0]['Effect'] == k8s_assume_role_policy_deny['Statement'][0]['Effect']
 
         # Delete the assume role policy document.
         updates = {

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -277,19 +277,4 @@ class TestRole:
         latest_assume_role_policy_doc = role.get_assume_role_policy(role_name)
         assert latest_assume_role_policy_doc['Statement'][0]['Effect'] == k8s_assume_role_policy_deny['Statement'][0]['Effect']
 
-        # Delete the assume role policy document.
-        updates = {
-            "spec": {
-                "assumeRolePolicyDocument": None,
-            },
-        }
-        k8s.patch_custom_resource(ref, updates)
-        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-
-        cr = k8s.get_resource(ref)
-        assert cr is not None
-        assert "spec" in cr
-        assert 'assumeRolePolicyDocument' not in cr['spec']
-
-        latest_assume_role_policy_doc = role.get_assume_role_policy(role_name)
-        assert len(latest_assume_role_policy_doc) == 0
+        # Assume role policies cannot be entirely deleted, so CRU is tested here.


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1448, but this also includes `AssumeRolePolicyDocument` in general as these are not updated regardless of whether the document change is valid or not.

Description of changes:

Adds a call to sync the `spec.assumeRolePolicyDocument` object, alongside the corresponding AWS API calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
