### PR TITLE
Fix spelling errors and add codespell github action

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = ./.git,./go.local.sum
+check-filenames =
+check-hidden =
+quiet = 2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,10 @@
+---
+name: push
+on:
+  - push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+      - uses: codespell-project/actions-codespell@master

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -94,7 +94,7 @@ syntax/tree.go (from RegexTree.cs and RegexNode.cs): ported literally as possibl
 
 syntax/writer.go (from RegexWriter.cs): ported literally with minor changes to make it more Go-ish.
 
-match.go (from RegexMatch.cs): ported, simplified, and changed to handle Go's lack of inheritence.
+match.go (from RegexMatch.cs): ported, simplified, and changed to handle Go's lack of inheritance.
 
 regexp.go (from Regex.cs and RegexOptions.cs): conceptually serves the same "starting point", but is simplified 
     and changed to handle differences in C# strings and Go strings/runes.  

--- a/pkg/resource/group/resource.go
+++ b/pkg/resource/group/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/open_id_connect_provider/resource.go
+++ b/pkg/resource/open_id_connect_provider/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/policy/resource.go
+++ b/pkg/resource/policy/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/role/resource.go
+++ b/pkg/resource/role/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/user/resource.go
+++ b/pkg/resource/user/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }


### PR DESCRIPTION
Fix spelling errors in docs and comments
Use codespell to spell check the code and documentation.

Correct spelling is a great way to look more professional and
demonstrate higher quality. And it catches a surprisingly number of
actual errors, too.