### PR TITLE
late initialize Role.Description

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-05-01T22:15:40Z"
-  build_hash: 6657565bb742e5cd4cd340d01d5e4786b5fbabc0
-  go_version: go1.19
-  version: v0.26.0
+  build_date: "2023-05-03T16:53:00Z"
+  build_hash: 06bf1325851814e1f8004dc70fb50f5023fdf24c
+  go_version: go1.19.4
+  version: v0.26.0-1-g06bf132
 api_directory_checksum: 26341f700d12dfcd4033cf4203492fa381daa7b0
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 0a343bca2be29176e9388a2cc3d54461162c5984
+  file_checksum: 0dfb99b66da90fef5d3bd6eb512243bf87f6d16d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -167,6 +167,9 @@ resources:
         set:
           # The input and output shapes are different...
           - from: PermissionsBoundary.PermissionsBoundaryArn
+      Description:
+        # See above in Policy resource about why this is here.
+        late_initialize: {}
       Path:
         late_initialize: {}
       # In order to support attaching zero or more policies to a role, we use

--- a/generator.yaml
+++ b/generator.yaml
@@ -167,6 +167,9 @@ resources:
         set:
           # The input and output shapes are different...
           - from: PermissionsBoundary.PermissionsBoundaryArn
+      Description:
+        # See above in Policy resource about why this is here.
+        late_initialize: {}
       Path:
         late_initialize: {}
       # In order to support attaching zero or more policies to a role, we use

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,10 +145,7 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. See
-                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-                                for how the garbage collector interacts with this
-                                field and enforces the foreground deletion. Defaults
+                                key-value store until this reference is removed. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -33,7 +33,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "watch-namespace" -}}
 {{- if eq .Values.installScope "namespace" -}}
-{{- .Release.Namespace -}}
+{{ .Values.watchNamespace | default .Release.Namespace }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -196,6 +196,9 @@
       "type": "string",
       "enum": ["cluster", "namespace"]
     },
+    "watchNamespace": {
+      "type": "string"
+    },    
     "resourceTags": {
       "type": "array",
       "items": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -72,6 +72,10 @@ log:
 # cluster wide.
 installScope: cluster
 
+# Set the value of the "namespace" to be watched by the controller
+# This value is only used when the `installScope` is set to "namespace". If left empty, the default value is the release namespace for the chart.
+watchNamespace: ""
+
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on
   # resources that it manages.

--- a/pkg/resource/role/manager.go
+++ b/pkg/resource/role/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"MaxSessionDuration", "Path"}
+var lateInitializeFieldNames = []string{"Description", "MaxSessionDuration", "Path"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -249,6 +249,9 @@ func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.Description == nil {
+		return true
+	}
 	if ko.Spec.MaxSessionDuration == nil {
 		return true
 	}
@@ -266,6 +269,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 ) acktypes.AWSResource {
 	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.Description != nil && latestKo.Spec.Description == nil {
+		latestKo.Spec.Description = observedKo.Spec.Description
+	}
 	if observedKo.Spec.MaxSessionDuration != nil && latestKo.Spec.MaxSessionDuration == nil {
 		latestKo.Spec.MaxSessionDuration = observedKo.Spec.MaxSessionDuration
 	}

--- a/templates/hooks/role/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/role/sdk_create_post_set_output.go.tpl
@@ -1,8 +1,8 @@
     if ko.Spec.AssumeRolePolicyDocument != nil {
-		if doc, err := decodeDocument(*ko.Spec.AssumeRolePolicyDocument); err != nil {
-			return nil, err
-		} else {
-			ko.Spec.AssumeRolePolicyDocument = &doc
-		}
-	}
+        if doc, err := decodeDocument(*ko.Spec.AssumeRolePolicyDocument); err != nil {
+            return nil, err
+        } else {
+            ko.Spec.AssumeRolePolicyDocument = &doc
+        }
+    }
     ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -32,6 +32,7 @@ DELETE_WAIT_AFTER_SECONDS = 10
 CHECK_STATUS_WAIT_SECONDS = 10
 MODIFY_WAIT_AFTER_SECONDS = 10
 MAX_SESS_DURATION = 3600 # Note: minimum of 3600 seconds...
+ROLE_DESC = "a simple role"
 
 
 @pytest.fixture(scope="module")
@@ -41,7 +42,7 @@ def simple_role():
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements['ROLE_NAME'] = role_name
-    replacements['ROLE_DESCRIPTION'] = role_desc
+    replacements['ROLE_DESCRIPTION'] = ROLE_DESC
     replacements['MAX_SESSION_DURATION'] = str(MAX_SESS_DURATION)
 
     resource_data = load_resource(
@@ -91,6 +92,10 @@ class TestRole:
         assert 'spec' in cr
         assert 'maxSessionDuration' in cr['spec']
         assert cr['spec']['maxSessionDuration'] == MAX_SESS_DURATION
+        # Check that the Description field has not been removed.
+        # See: https://github.com/aws-controllers-k8s/community/issues/1772
+        assert 'description' in cr['spec']
+        assert cr['spec']['description'] == ROLE_DESC
 
         condition.assert_synced(ref)
 


### PR DESCRIPTION
The IAM CreateRole API response always has a nil Description field, even if the CreateRole API request contains a non-nil Description field. This is totally broken behaviour that also exists for the CreatePolicy API but apparently won't be fixed by IAM. So, this commit papers over that flaw in the API by late-initializing Role.Description to the (correct) non-nil value from the DescribeRole API response.

Fixes Issue aws-controllers-k8s/community#1772

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
