### PR TITLE
Fix bug in updating `user.spec.inlinePolicies`

### DIFF
--- a/pkg/resource/user/hooks.go
+++ b/pkg/resource/user/hooks.go
@@ -234,6 +234,11 @@ func (rm *resourceManager) syncInlinePolicies(
 		}
 	}
 	for _, pair := range toDelete {
+		// do not remove elements we just updated with `addInlinePolicy`
+		if _, ok := lo.Find(toAdd, func(entry lo.Entry[string, string]) bool { return entry.Key == pair.Key }); ok {
+			continue
+		}
+
 		polName := pair.Key
 		rlog.Debug(
 			"removing inline policy from user",

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@75752b2
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@371852014efcb8c26c454f861eb546c93a48f205

--- a/test/e2e/tests/test_user.py
+++ b/test/e2e/tests/test_user.py
@@ -217,7 +217,7 @@ class TestUser:
         assert 's3get' in latest_inline_policies
         assert 'ec2get' in latest_inline_policies
 
-        # expect s3get policy document to change into inlinde_doc_s3_get_object
+        # expect s3get policy document to change into inline_doc_s3_get_object
         got_pol_doc = latest_inline_policies['s3get']
         nospace_got_doc = "".join(c for c in got_pol_doc if not c.isspace())
         nospace_exp_doc = "".join(c for c in inline_doc_s3_get_object if not c.isspace())


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/1906

The bug occurs when updating an existing item in `spec.inlinePolicies`.
The code incorrectly includes both the old(to remove) and new(to
add)values when using `lo.Difference`. This causes the code to first
attempt to replace the xisting policies with a call to
`iam::PutUserPolicy` and then mistakenly "delete" them right after.

This patch fixes this bug by calling `lo.Find` to double check whether
we need to keep an inline policy (if it only needs to be updated)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
