### PR TITLE
(fix) custom service account in helm

### DIFF
--- a/helm/templates/leader-election-role-binding.yaml
+++ b/helm/templates/leader-election-role-binding.yaml
@@ -14,5 +14,5 @@ roleRef:
   name: iam-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: ack-iam-controller
+  name:{{ include "service-account.name" . }}
   namespace: {{ .Release.Namespace }}{{- end }}


### PR DESCRIPTION
## Issue

While using helm, if you pass a custom name other than `ack-iam-controller`, then the controller pod gets stuck and shows the following error: -

```
2023-09-13T14:43:19.072Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "0.0.0.0:8080"}
2023-09-13T14:43:19.073Z	INFO	setup	initializing service controller	{"aws.service": "iam"}
2023-09-13T14:43:19.278Z	INFO	setup	starting manager	{"aws.service": "iam"}
2023-09-13T14:43:19.278Z	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
I0913 14:43:19.278700       1 leaderelection.go:248] attempting to acquire leader lease ack-system/ack-iam.services.k8s.aws...
E0913 14:43:19.280349       1 leaderelection.go:330] error retrieving resource lock ack-system/ack-iam.services.k8s.aws: leases.coordination.k8s.io "ack-iam.services.k8s.aws" is forbidden: User "system:serviceaccount:ack-system:ack-iam-controller-sa" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "ack-system"
```
(I tried passing in `ack-iam-controller-sa`)

The pod is no longer able to do anything.