### PR TITLE
Add chart prefix when including aws.credentials.secret_mount_path

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -44,7 +44,7 @@ If release name contains chart name it will be used as a full name.
 
 {{/* The path the shared credentials file is mounted */}}
 {{- define "ack-iam-controller.aws.credentials.path" -}}
-{{- printf "%s/%s" (include "aws.credentials.secret_mount_path" .) .Values.aws.credentials.secretKey -}}
+{{- printf "%s/%s" (include "ack-iam-controller.aws.credentials.secret_mount_path" .) .Values.aws.credentials.secretKey -}}
 {{- end -}}
 
 {{/* The rules a of ClusterRole or Role */}}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Currently we receive the following error when trying to use a credentials secret with the helm chart:
```

helm template --set aws.credentials.secretName=ack-iam ./helm --debug                                                                      

Error: template: iam-chart/templates/deployment.yaml:112:20: executing "iam-chart/templates/deployment.yaml" at <include "ack-iam-controller.aws.credentials.path" .>: error calling include: template: iam-chart/templates/_helpers.tpl:47:20: executing "ack-iam-controller.aws.credentials.path" at <include "aws.credentials.secret_mount_path" .>: error calling include: template: no template "aws.credentials.secret_mount_path" associated with template "gotpl"
helm.go:84: [debug] template: iam-chart/templates/deployment.yaml:112:20: executing "iam-chart/templates/deployment.yaml" at <include "ack-iam-controller.aws.credentials.path" .>: error calling include: template: iam-chart/templates/_helpers.tpl:47:20: executing "ack-iam-controller.aws.credentials.path" at <include "aws.credentials.secret_mount_path" .>: error calling include: template: no template "aws.credentials.secret_mount_path" associated with template "gotpl"

```
Adding the chart prefix as it is defined here is solving this issue:

https://github.com/aws-controllers-k8s/iam-controller/blob/d371e9f6b51446eaee18d6efe546d20d81804be2/helm/templates/_helpers.tpl#L41

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
