### PR TITLE
Add tests for cross namespace resource reference

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2024-07-19T22:53:13Z"
-  build_hash: f0a0f42d507c550c2b063a192b3b43e4522bdd9c
+  build_date: "2024-07-29T23:59:41Z"
+  build_hash: 49afe38983d285f926b51b6d34e39a4d9aeffb85
   go_version: go1.22.5
-  version: v0.35.0
+  version: v0.35.0-2-g49afe38
 api_directory_checksum: 761a2c708651b0273bf39d98dddaf029de23d337
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0

--- a/config/crd/bases/iam.services.k8s.aws_groups.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_groups.yaml
@@ -104,6 +104,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        namespace:
+                          type: string
                       type: object
                   type: object
                 type: array

--- a/config/crd/bases/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_instanceprofiles.yaml
@@ -100,6 +100,8 @@ spec:
                     properties:
                       name:
                         type: string
+                      namespace:
+                        type: string
                     type: object
                 type: object
               tags:

--- a/config/crd/bases/iam.services.k8s.aws_roles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_roles.yaml
@@ -162,6 +162,8 @@ spec:
                     properties:
                       name:
                         type: string
+                      namespace:
+                        type: string
                     type: object
                 type: object
               policies:
@@ -181,6 +183,8 @@ spec:
                         k8s resource for finding the identifier(Id/ARN/Name)
                       properties:
                         name:
+                          type: string
+                        namespace:
                           type: string
                       type: object
                   type: object

--- a/config/crd/bases/iam.services.k8s.aws_users.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_users.yaml
@@ -116,6 +116,8 @@ spec:
                     properties:
                       name:
                         type: string
+                      namespace:
+                        type: string
                     type: object
                 type: object
               policies:
@@ -135,6 +137,8 @@ spec:
                         k8s resource for finding the identifier(Id/ARN/Name)
                       properties:
                         name:
+                          type: string
+                        namespace:
                           type: string
                       type: object
                   type: object

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.35.0
+	github.com/aws-controllers-k8s/runtime v0.35.1-0.20240719172343-a132c887e8d4
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/go-logr/logr v1.4.1
 	github.com/micahhausler/aws-iam-policy v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/a-hilaly/aws-iam-policy v0.0.0-20231121054900-2c56e839ca53 h1:2uNM0nR2WUDN88EYFxjEaroH+PZJ6k/h9kl+KO0dWVc=
 github.com/a-hilaly/aws-iam-policy v0.0.0-20231121054900-2c56e839ca53/go.mod h1:Ojgst9ZFn+VEEJpqtuw/LxVGqEf2+hwWBlkYWvF/XWM=
-github.com/aws-controllers-k8s/runtime v0.35.0 h1:kLRLFOAcaFJRv/aEiWtb0qhlxFpwvmx6shCWNc1Tuas=
-github.com/aws-controllers-k8s/runtime v0.35.0/go.mod h1:gI2pWb20UGLP2SnHf1a1VzTd7iVVy+/I9VAzT0Y+Dew=
+github.com/aws-controllers-k8s/runtime v0.35.1-0.20240719172343-a132c887e8d4 h1:CW58T4qFJpoF37hCPlV1NHCc6mdxNf6jdvLobVolSY0=
+github.com/aws-controllers-k8s/runtime v0.35.1-0.20240719172343-a132c887e8d4/go.mod h1:gI2pWb20UGLP2SnHf1a1VzTd7iVVy+/I9VAzT0Y+Dew=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/helm/crds/iam.services.k8s.aws_groups.yaml
+++ b/helm/crds/iam.services.k8s.aws_groups.yaml
@@ -104,6 +104,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        namespace:
+                          type: string
                       type: object
                   type: object
                 type: array

--- a/helm/crds/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/helm/crds/iam.services.k8s.aws_instanceprofiles.yaml
@@ -100,6 +100,8 @@ spec:
                     properties:
                       name:
                         type: string
+                      namespace:
+                        type: string
                     type: object
                 type: object
               tags:

--- a/helm/crds/iam.services.k8s.aws_roles.yaml
+++ b/helm/crds/iam.services.k8s.aws_roles.yaml
@@ -162,6 +162,8 @@ spec:
                     properties:
                       name:
                         type: string
+                      namespace:
+                        type: string
                     type: object
                 type: object
               policies:
@@ -181,6 +183,8 @@ spec:
                         k8s resource for finding the identifier(Id/ARN/Name)
                       properties:
                         name:
+                          type: string
+                        namespace:
                           type: string
                       type: object
                   type: object

--- a/helm/crds/iam.services.k8s.aws_users.yaml
+++ b/helm/crds/iam.services.k8s.aws_users.yaml
@@ -116,6 +116,8 @@ spec:
                     properties:
                       name:
                         type: string
+                      namespace:
+                        type: string
                     type: object
                 type: object
               policies:
@@ -135,6 +137,8 @@ spec:
                         k8s resource for finding the identifier(Id/ARN/Name)
                       properties:
                         name:
+                          type: string
+                        namespace:
                           type: string
                       type: object
                   type: object

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -238,3 +238,12 @@ rules:
   - patch
   - update
 {{- end }}
+
+{{/* Convert k/v map to string like: "key1=value1,key2=value2,..." */}}
+{{- define "ack-iam-controller.feature-gates" -}}
+{{- $list := list -}}
+{{- range $k, $v := .Values.featureGates -}}
+{{- $list = append $list (printf "%s=%s" $k ( $v | toString)) -}}
+{{- end -}}
+{{ join "," $list }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
         - --reconcile-resource-max-concurrent-syncs
         - "$(RECONCILE_RESOURCE_MAX_CONCURRENT_SYNCS_{{ $key | upper }})"
 {{- end }}
+{{- if .Values.featureGates}}
+        - --feature-gates
+        - "$(FEATURE_GATES)"
+{{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller
@@ -122,6 +126,10 @@ spec:
 {{- range $key, $value := .Values.reconcile.resourceMaxConcurrentSyncs }}
         - name: RECONCILE_RESOURCE_MAX_CONCURRENT_SYNCS_{{ $key | upper }}
           value: {{ $key }}={{ $value }}
+{{- end }}
+{{- if .Values.featureGates}}
+        - name: FEATURE_GATES
+          value: {{ include "ack-iam-controller.feature-gates" . }}
 {{- end }}
         {{- if .Values.aws.credentials.secretName }}
         - name: AWS_SHARED_CREDENTIALS_FILE

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -268,6 +268,13 @@
       "type": "object"
     }
   },
+  "featureGates": {
+    "description": "Feature gates settings",
+    "type": "object",
+    "additionalProperties": {
+      "type": "boolean"
+    }
+  },
   "required": [
     "image",
     "deployment",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -153,3 +153,10 @@ leaderElection:
   # will attempt to use the namespace of the service account mounted to the Controller
   # pod.
   namespace: ""
+
+# Configuration for feature gates.  These are optional controller features that
+# can be individually enabled ("true") or disabled ("false") by adding key/value
+# pairs below.
+featureGates: {}
+  # featureGate1: true
+  # featureGate2: false

--- a/pkg/resource/group/references.go
+++ b/pkg/resource/group/references.go
@@ -56,12 +56,11 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	namespace := res.MetaObject().GetNamespace()
 	ko := rm.concreteResource(res).ko
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if fieldHasReferences, err := rm.resolveReferenceForPolicies(ctx, apiReader, namespace, ko); err != nil {
+	if fieldHasReferences, err := rm.resolveReferenceForPolicies(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -87,7 +86,6 @@ func validateReferenceFields(ko *svcapitypes.Group) error {
 func (rm *resourceManager) resolveReferenceForPolicies(
 	ctx context.Context,
 	apiReader client.Reader,
-	namespace string,
 	ko *svcapitypes.Group,
 ) (hasReferences bool, err error) {
 	for _, f0iter := range ko.Spec.PolicyRefs {
@@ -96,6 +94,10 @@ func (rm *resourceManager) resolveReferenceForPolicies(
 			arr := f0iter.From
 			if arr.Name == nil || *arr.Name == "" {
 				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PolicyRefs")
+			}
+			namespace := ko.ObjectMeta.GetNamespace()
+			if arr.Namespace != nil && *arr.Namespace != "" {
+				namespace = *arr.Namespace
 			}
 			obj := &svcapitypes.Policy{}
 			if err := getReferencedResourceState_Policy(ctx, apiReader, obj, *arr.Name, namespace); err != nil {

--- a/pkg/resource/user/references.go
+++ b/pkg/resource/user/references.go
@@ -60,18 +60,17 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	namespace := res.MetaObject().GetNamespace()
 	ko := rm.concreteResource(res).ko
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if fieldHasReferences, err := rm.resolveReferenceForPermissionsBoundary(ctx, apiReader, namespace, ko); err != nil {
+	if fieldHasReferences, err := rm.resolveReferenceForPermissionsBoundary(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	if fieldHasReferences, err := rm.resolveReferenceForPolicies(ctx, apiReader, namespace, ko); err != nil {
+	if fieldHasReferences, err := rm.resolveReferenceForPolicies(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -101,7 +100,6 @@ func validateReferenceFields(ko *svcapitypes.User) error {
 func (rm *resourceManager) resolveReferenceForPermissionsBoundary(
 	ctx context.Context,
 	apiReader client.Reader,
-	namespace string,
 	ko *svcapitypes.User,
 ) (hasReferences bool, err error) {
 	if ko.Spec.PermissionsBoundaryRef != nil && ko.Spec.PermissionsBoundaryRef.From != nil {
@@ -109,6 +107,10 @@ func (rm *resourceManager) resolveReferenceForPermissionsBoundary(
 		arr := ko.Spec.PermissionsBoundaryRef.From
 		if arr.Name == nil || *arr.Name == "" {
 			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PermissionsBoundaryRef")
+		}
+		namespace := ko.ObjectMeta.GetNamespace()
+		if arr.Namespace != nil && *arr.Namespace != "" {
+			namespace = *arr.Namespace
 		}
 		obj := &svcapitypes.Policy{}
 		if err := getReferencedResourceState_Policy(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
@@ -178,7 +180,6 @@ func getReferencedResourceState_Policy(
 func (rm *resourceManager) resolveReferenceForPolicies(
 	ctx context.Context,
 	apiReader client.Reader,
-	namespace string,
 	ko *svcapitypes.User,
 ) (hasReferences bool, err error) {
 	for _, f0iter := range ko.Spec.PolicyRefs {
@@ -187,6 +188,10 @@ func (rm *resourceManager) resolveReferenceForPolicies(
 			arr := f0iter.From
 			if arr.Name == nil || *arr.Name == "" {
 				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PolicyRefs")
+			}
+			namespace := ko.ObjectMeta.GetNamespace()
+			if arr.Namespace != nil && *arr.Namespace != "" {
+				namespace = *arr.Namespace
 			}
 			obj := &svcapitypes.Policy{}
 			if err := getReferencedResourceState_Policy(ctx, apiReader, obj, *arr.Name, namespace); err != nil {

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -32,6 +32,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "slow: mark test as slow to run"
     )
+    config.addinivalue_line(
+        "markers", "resource_data: mark test with data to use when creating fixture"
+    )
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):

--- a/test/e2e/resources/policy_simple_namespace.yaml
+++ b/test/e2e/resources/policy_simple_namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Policy
+metadata:
+  name: $POLICY_NAME
+  namespace: $POLICY_NAMESPACE 
+spec:
+  name: $POLICY_NAME
+  description: $POLICY_DESCRIPTION
+  policyDocument: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:ListAllMyBuckets","Resource":"arn:aws:s3:::*"},{"Effect":"Allow","Action":["s3:List*"],"Resource":["*"]}]}'
+  tags:
+    - key: tag1
+      value: val1

--- a/test/e2e/resources/role_referring_namespace.yaml
+++ b/test/e2e/resources/role_referring_namespace.yaml
@@ -1,0 +1,25 @@
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Role
+metadata:
+  name: $ROLE_NAME
+spec:
+  name: $ROLE_NAME
+  description: "a role that refers to a policy"
+  maxSessionDuration: 3600
+  assumeRolePolicyDocument: >
+    {
+      "Version":"2012-10-17",
+      "Statement": [{
+        "Effect":"Allow",
+        "Principal": {
+          "Service": [
+            "ec2.amazonaws.com"
+          ]
+        },
+        "Action": ["sts:AssumeRole"]
+      }]
+    }
+  policyRefs:
+    - from:
+        name: $POLICY_NAME
+        namespace: $POLICY_NAMESPACE


### PR DESCRIPTION
Issue [#1777](https://github.com/aws-controllers-k8s/community/issues/1777)

Description of changes:
* Adding new e2e test suites to validate our recently introduced feature ["cross namespace resource references"](https://github.com/aws-controllers-k8s/code-generator/pull/532). In order to test this feature, we added a new feature to allow new namespace creation, from which resources will be referenced (Policy in this case).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
