### PR TITLE
wrong chart name

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: iam-chart
+name: iam-controller
 description: A Helm chart for the ACK service controller for AWS Identity & Access Management (IAM)
 version: 1.3.10
 appVersion: 1.3.10


### PR DESCRIPTION
chart name should be iam-controller and not iam-chart based on the folder name

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
