### PR TITLE
remove getImmutableFieldChanges references from hooks

### DIFF
--- a/pkg/resource/instance_profile/hooks.go
+++ b/pkg/resource/instance_profile/hooks.go
@@ -2,13 +2,10 @@ package instance_profile
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	commonutil "github.com/aws-controllers-k8s/iam-controller/pkg/util"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/iam"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -25,12 +22,6 @@ func (rm *resourceManager) customUpdateInstanceProfile(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.customUpdateInstanceProfile")
 	defer func() { exit(err) }()
-
-	// Do not proceed with update if an immutable field was updated
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 
 	ko := desired.ko.DeepCopy()
 

--- a/pkg/resource/open_id_connect_provider/hooks.go
+++ b/pkg/resource/open_id_connect_provider/hooks.go
@@ -15,12 +15,10 @@ package open_id_connect_provider
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/iam"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -39,11 +37,6 @@ func (rm *resourceManager) customUpdateOpenIDConnectProvider(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.customUpdateOpenIDConnectProvider")
 	defer func() { exit(err) }()
-
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 
 	if delta.DifferentAt("Spec.Thumbprints") {
 		// Update the thumbprint list

--- a/test/e2e/tests/test_open_id_connect_provider.py
+++ b/test/e2e/tests/test_open_id_connect_provider.py
@@ -138,16 +138,3 @@ class TestOpenIdConnectProvider:
         after_update_expected_tags = [{"Key": "key2", "Value": "val2"}]
         latest_tags = open_id_connect_provider.get_tags(oidc_provider_arn)
         assert tag.cleaned(latest_tags) == after_update_expected_tags
-
-        # validate that changing the URL results in an advisory condition
-        update_url = {"spec": {"url": "https://other.example.com"}}
-        logging.debug(f"\n\n**** OIDCProvider update of URL intended to fail")
-        k8s.patch_custom_resource(ref, update_url)
-        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-
-        condition.assert_not_synced(ref)
-        condition.assert_type_status(
-            ref,
-            cond_type_match=condition.CONDITION_TYPE_TERMINAL,
-            cond_status_match=True,
-        )


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove `getImmutableFieldChanges` from hooks to support cel immutability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
