### PR TITLE
fix: remove cpu limit from resources in values.yaml and update schema accordingly

### DIFF
--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -147,8 +147,7 @@
             }
           },
           "required": [
-              "memory",
-              "cpu"
+              "memory"
           ],
           "type": "object"
         }

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -144,12 +144,6 @@
                 { "type": "number" },
                 { "type": "string" }
               ]
-            },
-            "cpu": {
-              "oneOf": [
-                { "type": "number" },
-                { "type": "string" }
-              ]
             }
           },
           "required": [

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,7 +81,6 @@ resources:
     cpu: "50m"
   limits:
     memory: "128Mi"
-    cpu: "100m"
 
 aws:
   # If specified, use the AWS region for AWS API calls

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,6 +81,7 @@ resources:
     cpu: "50m"
   limits:
     memory: "128Mi"
+    # cpu: "100m"  # Optional: Uncomment to set a CPU limit (may cause throttling)
 
 aws:
   # If specified, use the AWS region for AWS API calls


### PR DESCRIPTION
Description of changes:

Why remove `cpu` limits:

Setting CPU limits in Kubernetes can lead to unnecessary throttling due to how the Linux kernel enforces cgroup quotas. When a container hits its CPU limit, it is throttled even if the node has available CPU capacity. This can degrade application performance, especially for bursty or latency-sensitive workloads.

In our environment, we use Karpenter for dynamic provisioning. Karpenter works best when it can observe actual resource usage. Setting cpu requests without limits allows the scheduler and Karpenter to make better decisions about bin-packing and scaling, while avoiding performance degradation from artificial throttling.

We also enforce this practice with a Kyverno policy that disallows setting CPU limits, helping ensure consistent resource behavior cluster-wide.

Reference: [Kubernetes docs on CPU limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#cpu)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
