### PR TITLE
tests: Ready condition rename for iam-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T16:50:59Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:39:00Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/iam.services.k8s.aws_groups.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_groups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: groups.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_instanceprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instanceprofiles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_openidconnectproviders.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_openidconnectproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: openidconnectproviders.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_policies.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: policies.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_roles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: roles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_servicelinkedroles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_servicelinkedroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicelinkedroles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_users.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/a-hilaly/aws-iam-policy v0.0.0-20231121054900-2c56e839ca53 h1:2uNM0nR2WUDN88EYFxjEaroH+PZJ6k/h9kl+KO0dWVc=
 github.com/a-hilaly/aws-iam-policy v0.0.0-20231121054900-2c56e839ca53/go.mod h1:Ojgst9ZFn+VEEJpqtuw/LxVGqEf2+hwWBlkYWvF/XWM=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -86,6 +84,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/iam.services.k8s.aws_groups.yaml
+++ b/helm/crds/iam.services.k8s.aws_groups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: groups.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/helm/crds/iam.services.k8s.aws_instanceprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instanceprofiles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_openidconnectproviders.yaml
+++ b/helm/crds/iam.services.k8s.aws_openidconnectproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: openidconnectproviders.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_policies.yaml
+++ b/helm/crds/iam.services.k8s.aws_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: policies.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_roles.yaml
+++ b/helm/crds/iam.services.k8s.aws_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: roles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_servicelinkedroles.yaml
+++ b/helm/crds/iam.services.k8s.aws_servicelinkedroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicelinkedroles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_users.yaml
+++ b/helm/crds/iam.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/group/references.go
+++ b/pkg/resource/group/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -134,8 +135,9 @@ func getReferencedResourceState_Policy(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Policy",
 				namespace, name)
@@ -146,14 +148,14 @@ func getReferencedResourceState_Policy(
 			"Policy",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Policy",
 			namespace, name)

--- a/pkg/resource/instance_profile/references.go
+++ b/pkg/resource/instance_profile/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -129,8 +130,9 @@ func getReferencedResourceState_Role(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Role",
 				namespace, name)
@@ -141,14 +143,14 @@ func getReferencedResourceState_Role(
 			"Role",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Role",
 			namespace, name)

--- a/pkg/resource/role/references.go
+++ b/pkg/resource/role/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -143,8 +144,9 @@ func getReferencedResourceState_Policy(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Policy",
 				namespace, name)
@@ -155,14 +157,14 @@ func getReferencedResourceState_Policy(
 			"Policy",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Policy",
 			namespace, name)

--- a/pkg/resource/user/references.go
+++ b/pkg/resource/user/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -143,8 +144,9 @@ func getReferencedResourceState_Policy(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Policy",
 				namespace, name)
@@ -155,14 +157,14 @@ func getReferencedResourceState_Policy(
 			"Policy",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Policy",
 			namespace, name)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@10ce1ccf0f723933960e04c972808d9b4015ba50
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428

--- a/test/e2e/tests/test_descriptions.py
+++ b/test/e2e/tests/test_descriptions.py
@@ -122,7 +122,7 @@ class TestRole:
         role_name = ref.name
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
         condition.assert_type_status(
             ref,
             cond_type_match=condition.CONDITION_TYPE_LATE_INITIALIZED,
@@ -136,7 +136,7 @@ class TestRole:
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = role.get(role_name)
         assert latest is not None
@@ -146,7 +146,7 @@ class TestRole:
         ref, res = policy_with_no_description
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
         condition.assert_type_status(
             ref,
             cond_type_match=condition.CONDITION_TYPE_LATE_INITIALIZED,

--- a/test/e2e/tests/test_group.py
+++ b/test/e2e/tests/test_group.py
@@ -75,7 +75,7 @@ class TestGroup:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest_policy_arns = group.get_attached_policy_arns(group_name)
         assert latest_policy_arns == []

--- a/test/e2e/tests/test_open_id_connect_provider.py
+++ b/test/e2e/tests/test_open_id_connect_provider.py
@@ -108,7 +108,7 @@ class TestOpenIdConnectProvider:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest_oidcp_boto3 = open_id_connect_provider.get(oidc_provider_arn)
 

--- a/test/e2e/tests/test_policy.py
+++ b/test/e2e/tests/test_policy.py
@@ -129,7 +129,7 @@ class TestPolicy:
 
         time.sleep(CHECK_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         # check update code path for tags...
         latest_tags = policy.get_tags(policy_arn)
@@ -152,7 +152,7 @@ class TestPolicy:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest_tags = policy.get_tags(policy_arn)
         after_update_expected_tags = [
@@ -174,7 +174,7 @@ class TestPolicy:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest_tags = policy.get_tags(policy_arn)
         after_update_expected_tags = [
@@ -229,7 +229,7 @@ class TestPolicy:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
         assert cr is not None
@@ -245,7 +245,7 @@ class TestPolicy:
     def test_policy_adopt_update(self, adopt_policy):
         ref, cr, policy_arn = adopt_policy
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         assert cr is not None
         assert 'status' in cr
@@ -282,7 +282,7 @@ class TestPolicy:
     def test_policy_adopt_or_create(self, adopt_policy):
         ref, cr, policy_arn = adopt_policy
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         assert cr is not None
         assert 'status' in cr

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -171,8 +171,8 @@ class TestReferences:
 
         time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
 
-        condition.assert_synced(policy_ref)
-        condition.assert_synced(role_ref)
+        condition.assert_ready(policy_ref)
+        condition.assert_ready(role_ref)
 
         role.wait_until_exists(role_name)
 
@@ -205,8 +205,8 @@ class TestReferences:
 
         time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
 
-        condition.assert_synced(policy_ref)
-        condition.assert_synced(role_ref)
+        condition.assert_ready(policy_ref)
+        condition.assert_ready(role_ref)
 
         role.wait_until_exists(role_name)
 

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -107,7 +107,7 @@ class TestRole:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         # Before we update the Role CR below, let's check to see that the
         # MaxSessionDuration field in the CR is still what we set in the
@@ -122,7 +122,7 @@ class TestRole:
         assert 'description' in cr['spec']
         assert cr['spec']['description'] == ROLE_DESC
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = role.get(role_name)
         assert latest is not None
@@ -142,7 +142,7 @@ class TestRole:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = role.get(role_name)
         assert latest is not None
@@ -163,7 +163,7 @@ class TestRole:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest_policy_arns = role.get_attached_policy_arns(role_name)
         assert latest_policy_arns == policy_arns
@@ -192,7 +192,7 @@ class TestRole:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         after_update_expected_tags = [
             {
@@ -297,7 +297,7 @@ class TestRole:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
         assert cr is not None
@@ -331,7 +331,7 @@ class TestRole:
         assert assume_role_policy_as_obj == k8s_assume_role_policy
 
         # make sure the resource is not in an "update infinite loop"
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         assume_role_policy_to_deny_doc = '''{
     "Version": "2012-10-17",
@@ -354,7 +354,7 @@ class TestRole:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
         assert cr is not None
@@ -373,13 +373,13 @@ class TestRole:
         # Assume role policies cannot be entirely deleted, so CRU is tested here.
 
         # make sure the resource is not in an "update infinite loop"
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
     
     def test_role_adopt(self, adopt_role):
         ref, cr = adopt_role
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         assert cr is not None
         assert 'status' in cr

--- a/test/e2e/tests/test_service_linked_role.py
+++ b/test/e2e/tests/test_service_linked_role.py
@@ -74,7 +74,7 @@ class TestServiceLinkedRole:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         # Validate the service-linked role exists
         latest = role.get(role_name)
@@ -92,7 +92,7 @@ class TestServiceLinkedRole:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = role.get(role_name)
         assert latest is not None

--- a/test/e2e/tests/test_user.py
+++ b/test/e2e/tests/test_user.py
@@ -76,7 +76,7 @@ class TestUser:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         latest = user.get(user_name)
         assert latest is not None


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._