### PR TITLE
Late Initialize OpenID Connect Provider Thumbprints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *~
 .idea
+.vscode
 /docs/site
 bin
 build

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-09-19T16:50:59Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-30T23:38:44Z"
+  build_hash: 37562000612658e62686882f1b4b924049d1e38c
+  go_version: go1.25.0
+  version: v0.52.0-5-g3756200
 api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 9e30795ffa094ac7b68fe2bcb6913b0a2d7bccba
+  file_checksum: ceef3af34f41f300f4d827886f35d272f50cb38c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -277,6 +277,8 @@ resources:
         is_immutable: true
         compare:
           is_ignored: true
+      Thumbprints:
+        late_initialize: {}
       Tags:
         compare:
           is_ignored: true

--- a/config/crd/bases/iam.services.k8s.aws_groups.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_groups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: groups.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_instanceprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instanceprofiles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_openidconnectproviders.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_openidconnectproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: openidconnectproviders.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_policies.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: policies.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_roles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: roles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_servicelinkedroles.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_servicelinkedroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicelinkedroles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/config/crd/bases/iam.services.k8s.aws_users.yaml
+++ b/config/crd/bases/iam.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/generator.yaml
+++ b/generator.yaml
@@ -277,6 +277,8 @@ resources:
         is_immutable: true
         compare:
           is_ignored: true
+      Thumbprints:
+        late_initialize: {}
       Tags:
         compare:
           is_ignored: true

--- a/helm/crds/iam.services.k8s.aws_groups.yaml
+++ b/helm/crds/iam.services.k8s.aws_groups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: groups.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/helm/crds/iam.services.k8s.aws_instanceprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instanceprofiles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_openidconnectproviders.yaml
+++ b/helm/crds/iam.services.k8s.aws_openidconnectproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: openidconnectproviders.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_policies.yaml
+++ b/helm/crds/iam.services.k8s.aws_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: policies.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_roles.yaml
+++ b/helm/crds/iam.services.k8s.aws_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: roles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_servicelinkedroles.yaml
+++ b/helm/crds/iam.services.k8s.aws_servicelinkedroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicelinkedroles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/iam.services.k8s.aws_users.yaml
+++ b/helm/crds/iam.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/open_id_connect_provider/manager.go
+++ b/pkg/resource/open_id_connect_provider/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=openidconnectproviders,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=openidconnectproviders/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"Thumbprints"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -248,6 +248,10 @@ func (rm *resourceManager) LateInitialize(
 func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.Thumbprints == nil {
+		return true
+	}
 	return false
 }
 
@@ -257,7 +261,12 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.Thumbprints != nil && latestKo.Spec.Thumbprints == nil {
+		latestKo.Spec.Thumbprints = observedKo.Spec.Thumbprints
+	}
+	return &resource{latestKo}
 }
 
 // IsSynced returns true if the resource is synced.

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -18,12 +18,14 @@ for them.
 from dataclasses import dataclass
 from acktest.bootstrapping import Resources
 from acktest.bootstrapping.iam import UserPolicies, Role
+from acktest.bootstrapping.cognito_identity import UserPool
 from e2e import bootstrap_directory
 
 @dataclass
 class BootstrapResources(Resources):
     AdoptedPolicy: UserPolicies
     AdoptedRole: Role
+    OIDCProviderUserPool: UserPool
 _bootstrap_resources = None
 
 def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.pkl") -> BootstrapResources:

--- a/test/e2e/resources/open_id_connect_provider_no_thumbprint.yaml
+++ b/test/e2e/resources/open_id_connect_provider_no_thumbprint.yaml
@@ -1,0 +1,12 @@
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: OpenIDConnectProvider
+metadata:
+  name: $OPEN_ID_CONNECT_PROVIDER_NAME
+spec:
+  url: $URL
+  clientIDs:
+    - $CLIENT_ID
+  tags:
+    - key: $TAG_KEY
+      value: $TAG_VALUE
+      

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -19,6 +19,7 @@ import json
 
 from acktest.bootstrapping import Resources, BootstrapFailureException
 from acktest.bootstrapping.iam import UserPolicies, Role
+from acktest.bootstrapping.cognito_identity import UserPool
 from e2e import bootstrap_directory
 from e2e.bootstrap_resources import BootstrapResources
 
@@ -38,7 +39,8 @@ def service_bootstrap() -> Resources:
     })
     resources = BootstrapResources(
         AdoptedPolicy=UserPolicies("adopted-policies", policy_documents=[sample_policy]),
-        AdoptedRole=Role("adopted-role", "eks.amazonaws.com", managed_policies=["arn:aws:iam::aws:policy/AmazonSQSFullAccess", "arn:aws:iam::aws:policy/AmazonEC2FullAccess"])
+        AdoptedRole=Role("adopted-role", "eks.amazonaws.com", managed_policies=["arn:aws:iam::aws:policy/AmazonSQSFullAccess", "arn:aws:iam::aws:policy/AmazonEC2FullAccess"]),
+        OIDCProviderUserPool=UserPool(name_prefix="oidc-test-pool")
     )
 
     try:


### PR DESCRIPTION
Issue #, if available: [2450](https://github.com/aws-controllers-k8s/community/issues/2450)

Description of changes:
Update the OpenID Connect Provider resource to late initialize the Thumbprints field when not provided. This avoids invalid requests being made to `UpdateOpenIDConnectProviderThumbprint` due to the Thumbprints field being nil.

- Mark `OpenIDConnectProvider.Thumbprints` as a late_initialize field in generator.yaml
- Add e2e test to verify that the Thumbprints field is populated with the value in AWS following creation of the resource and that subsequent reconcile doesn't trigger an invalid `UpdateOpenIDConnectProviderThumbprint` request.
- Add `.vscode` to `.gitignore`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
