### PR TITLE
Bug/assume role policy document delta

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:13:10Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
-  go_version: go1.26.2
-  version: v0.58.1
+  build_date: "2026-05-11T05:56:13Z"
+  build_hash: 119cbe3fb4412c17107b73761dac9eeef484f36a
+  go_version: go1.26.0
+  version: v0.58.1-7-g119cbe3
 api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: ceef3af34f41f300f4d827886f35d272f50cb38c
+  file_checksum: 5a412f0cf6a9b9774ccbe2c7214baf1b14bdb89e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-05-11T05:56:13Z"
+  build_date: "2026-05-11T19:46:40Z"
   build_hash: 119cbe3fb4412c17107b73761dac9eeef484f36a
   go_version: go1.26.0
   version: v0.58.1-7-g119cbe3

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -247,8 +247,7 @@ resources:
       InlinePolicies:
         type: map[string]*string
       AssumeRolePolicyDocument:
-        compare:
-          is_ignored: true
+        is_iam_policy: true
       Tags:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -247,8 +247,7 @@ resources:
       InlinePolicies:
         type: map[string]*string
       AssumeRolePolicyDocument:
-        compare:
-          is_ignored: true
+        is_iam_policy: true
       Tags:
         compare:
           is_ignored: true

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/iam-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.58.0
+	github.com/aws-controllers-k8s/runtime v0.58.2-0.20260511193322-75e738e89513
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.38.8
@@ -11,6 +11,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/samber/lo v1.37.0
 	github.com/spf13/pflag v1.0.9
+	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -52,7 +53,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/micahhausler/aws-iam-policy v0.4.4 // indirect
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.38.8
 	github.com/aws/smithy-go v1.22.2
 	github.com/go-logr/logr v1.4.3
-	github.com/micahhausler/aws-iam-policy v0.4.4
 	github.com/samber/lo v1.37.0
 	github.com/spf13/pflag v1.0.9
 	k8s.io/api v0.35.0
@@ -53,6 +52,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/micahhausler/aws-iam-policy v0.4.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/runtime v0.58.0 h1:PbM3hsM5z66BSPTb2CBBElYmGF3EgSbUO88efLXxL78=
-github.com/aws-controllers-k8s/runtime v0.58.0/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/runtime v0.58.2-0.20260511193322-75e738e89513 h1:tIFJVjOmdD/S40IUQ6RxTmhLDMGs+uyxi93GrUTOAdE=
+github.com/aws-controllers-k8s/runtime v0.58.2-0.20260511193322-75e738e89513/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -110,8 +110,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
-github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 h1:J1D4vj3/AVzVoo1allyJJD3mh7J6bPWXVoQHOBQ+p5Y=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/resource/role/delta.go
+++ b/pkg/resource/role/delta.go
@@ -43,6 +43,13 @@ func newResourceDelta(
 	}
 	customPreCompare(delta, a, b)
 
+	if ackcompare.HasNilDifference(a.ko.Spec.AssumeRolePolicyDocument, b.ko.Spec.AssumeRolePolicyDocument) {
+		delta.Add("Spec.AssumeRolePolicyDocument", a.ko.Spec.AssumeRolePolicyDocument, b.ko.Spec.AssumeRolePolicyDocument)
+	} else if a.ko.Spec.AssumeRolePolicyDocument != nil && b.ko.Spec.AssumeRolePolicyDocument != nil {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.AssumeRolePolicyDocument, *b.ko.Spec.AssumeRolePolicyDocument); err != nil || !equal {
+			delta.Add("Spec.AssumeRolePolicyDocument", a.ko.Spec.AssumeRolePolicyDocument, b.ko.Spec.AssumeRolePolicyDocument)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
 	} else if a.ko.Spec.Description != nil && b.ko.Spec.Description != nil {

--- a/pkg/resource/role/delta_test.go
+++ b/pkg/resource/role/delta_test.go
@@ -1,0 +1,421 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package role
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+
+	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+)
+
+// helper to build a *resource with only AssumeRolePolicyDocument set.
+func roleWithPolicy(doc string) *resource {
+	return &resource{
+		ko: &svcapitypes.Role{
+			Spec: svcapitypes.RoleSpec{
+				Name:                     aws.String("test-role"),
+				AssumeRolePolicyDocument: aws.String(doc),
+			},
+		},
+	}
+}
+
+func TestNewResourceDelta_AssumeRolePolicyDocument(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  string
+		latest   string
+		wantDiff bool
+	}{
+		{
+			name: "identical policies produce no diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name:    "whitespace differences produce no diff",
+			desired: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"eks.amazonaws.com"},"Action":"sts:AssumeRole"}]}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Principal": {
+							"Service": "eks.amazonaws.com"
+						},
+						"Action": "sts:AssumeRole"
+					}
+				]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "JSON key ordering differences produce no diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Action": "sts:AssumeRole",
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"}
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "statement ordering differences produce no diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Sid": "1", "Effect": "Allow", "Principal": {"Service": "eks.amazonaws.com"}, "Action": "sts:AssumeRole"},
+					{"Sid": "2", "Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}
+				]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Sid": "2", "Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"},
+					{"Sid": "1", "Effect": "Allow", "Principal": {"Service": "eks.amazonaws.com"}, "Action": "sts:AssumeRole"}
+				]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "Principal.Service array order difference produces no diff (issue scenario)",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {
+						"Service": ["ec2.amazonaws.com", "eks.amazonaws.com"]
+					},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {
+						"Service": ["eks.amazonaws.com", "ec2.amazonaws.com"]
+					},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "Condition key ordering difference produces no diff (issue scenario)",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABCDEF"},
+					"Action": "sts:AssumeRoleWithWebIdentity",
+					"Condition": {
+						"StringEquals": {
+							"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:aud": "sts.amazonaws.com",
+							"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:sub": ["system:serviceaccount:kube-system:aws-node"]
+						}
+					}
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABCDEF"},
+					"Action": "sts:AssumeRoleWithWebIdentity",
+					"Condition": {
+						"StringEquals": {
+							"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:sub": ["system:serviceaccount:kube-system:aws-node"],
+							"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:aud": "sts.amazonaws.com"
+						}
+					}
+				}]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "full issue scenario - Service array order AND Condition key order differ",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Principal": {
+							"Service": ["ec2.amazonaws.com", "eks.amazonaws.com"]
+						},
+						"Action": "sts:AssumeRole"
+					},
+					{
+						"Effect": "Allow",
+						"Principal": {
+							"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABCDEF"
+						},
+						"Action": "sts:AssumeRoleWithWebIdentity",
+						"Condition": {
+							"StringEquals": {
+								"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:aud": "sts.amazonaws.com",
+								"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:sub": [
+									"system:serviceaccount:kube-system:aws-node",
+									"system:serviceaccount:kube-system:cilium-operator",
+									"system:serviceaccount:kube-system:vpc-resource-controller"
+								]
+							}
+						}
+					}
+				]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Principal": {
+							"Service": ["eks.amazonaws.com", "ec2.amazonaws.com"]
+						},
+						"Action": "sts:AssumeRole"
+					},
+					{
+						"Effect": "Allow",
+						"Principal": {
+							"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABCDEF"
+						},
+						"Action": "sts:AssumeRoleWithWebIdentity",
+						"Condition": {
+							"StringEquals": {
+								"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:sub": [
+									"system:serviceaccount:kube-system:aws-node",
+									"system:serviceaccount:kube-system:cilium-operator",
+									"system:serviceaccount:kube-system:vpc-resource-controller"
+								],
+								"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:aud": "sts.amazonaws.com"
+							}
+						}
+					}
+				]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "Action as string vs array produces no diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": ["sts:AssumeRole"]
+				}]
+			}`,
+			wantDiff: false,
+		},
+		{
+			name: "actually different policies produce a diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "lambda.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			wantDiff: true,
+		},
+		{
+			name: "different Effect produces a diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Deny",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			wantDiff: true,
+		},
+		{
+			name: "additional statement produces a diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Effect": "Allow", "Principal": {"Service": "eks.amazonaws.com"}, "Action": "sts:AssumeRole"},
+					{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}
+				]
+			}`,
+			wantDiff: true,
+		},
+		{
+			name: "different Condition values produce a diff",
+			desired: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABCDEF"},
+					"Action": "sts:AssumeRoleWithWebIdentity",
+					"Condition": {
+						"StringEquals": {
+							"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:sub": "system:serviceaccount:kube-system:aws-node"
+						}
+					}
+				}]
+			}`,
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/ABCDEF"},
+					"Action": "sts:AssumeRoleWithWebIdentity",
+					"Condition": {
+						"StringEquals": {
+							"oidc.eks.us-west-2.amazonaws.com/id/ABCDEF:sub": "system:serviceaccount:kube-system:different-sa"
+						}
+					}
+				}]
+			}`,
+			wantDiff: true,
+		},
+		{
+			name:    "nil desired vs non-nil latest produces a diff",
+			desired: "",
+			latest: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Principal": {"Service": "eks.amazonaws.com"},
+					"Action": "sts:AssumeRole"
+				}]
+			}`,
+			wantDiff: true,
+		},
+		{
+			name:     "both nil produces no diff",
+			desired:  "",
+			latest:   "",
+			wantDiff: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var a, b *resource
+
+			if tc.desired == "" && tc.latest == "" {
+				// Both nil AssumeRolePolicyDocument
+				a = &resource{
+					ko: &svcapitypes.Role{
+						Spec: svcapitypes.RoleSpec{
+							Name: aws.String("test-role"),
+						},
+					},
+				}
+				b = &resource{
+					ko: &svcapitypes.Role{
+						Spec: svcapitypes.RoleSpec{
+							Name: aws.String("test-role"),
+						},
+					},
+				}
+			} else if tc.desired == "" {
+				a = &resource{
+					ko: &svcapitypes.Role{
+						Spec: svcapitypes.RoleSpec{
+							Name: aws.String("test-role"),
+						},
+					},
+				}
+				b = roleWithPolicy(tc.latest)
+			} else if tc.latest == "" {
+				a = roleWithPolicy(tc.desired)
+				b = &resource{
+					ko: &svcapitypes.Role{
+						Spec: svcapitypes.RoleSpec{
+							Name: aws.String("test-role"),
+						},
+					},
+				}
+			} else {
+				a = roleWithPolicy(tc.desired)
+				b = roleWithPolicy(tc.latest)
+			}
+
+			delta := newResourceDelta(a, b)
+
+			if tc.wantDiff {
+				assert.True(t, delta.DifferentAt("Spec.AssumeRolePolicyDocument"),
+					"expected a diff at Spec.AssumeRolePolicyDocument but got none")
+			} else {
+				assert.False(t, delta.DifferentAt("Spec.AssumeRolePolicyDocument"),
+					"expected no diff at Spec.AssumeRolePolicyDocument but got one")
+			}
+		})
+	}
+}

--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -15,16 +15,13 @@ package role
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
-	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/iam"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	awsiampolicy "github.com/micahhausler/aws-iam-policy/policy"
 	"github.com/samber/lo"
 
 	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
@@ -376,7 +373,6 @@ func customPreCompare(
 	b *resource,
 ) {
 	compareTags(delta, a, b)
-	compareAssumeRolePolicyDocument(delta, a, b)
 }
 
 // compareTags is a custom comparison function for comparing lists of Tag
@@ -392,42 +388,6 @@ func compareTags(
 		if !commonutil.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 		}
-	}
-}
-
-// compareAssumeRolePolicyDocument is a custom comparison function for
-// assumeRolePolicyDocuments. The reason why we need a custom function for
-// this fields is the API logic that trims all the trailing while spaces
-// string of provided documents.
-func compareAssumeRolePolicyDocument(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	// To handle the variability in shapes of JSON objects representing IAM policies,
-	// especially when it comes to statements, actions, and other fields, we need
-	// a custom json.Unmarshaller approach crafted to our specific needs. Luckily,
-	// it happens that @micahhausler buildta library dedicated to this very special
-	// need: github.com/micahhausler/aws-iam-policy.
-	//
-	// NOTE(a-hilaly): I'm pretty aware that there is an error that should be handled.
-	// However, unfortunetly, the `newResourceDelta` cannot return errors (for now),
-	// leaving us with only two solutions, panicking or ignoring the error. The first
-	// solution is an overkill as it will interrupt all the goroutines from functioning
-	// and causing the controller to enter in a 'CrashLoopBackOff' state, which is not
-	// fair, given that it's also is responsible of managing multiple objects of other
-	// different resources.
-	//
-	// TOOD(a-hilaly): To address this issue, concider changing the delta signature
-	// to return an error or take a context.Context to use the runtime logger. Both
-	// of these changes require runtime/code-generator changes.
-	var policyDocumentA awsiampolicy.Policy
-	_ = json.Unmarshal([]byte(*a.ko.Spec.AssumeRolePolicyDocument), &policyDocumentA)
-	var policyDocumentB awsiampolicy.Policy
-	_ = json.Unmarshal([]byte(*b.ko.Spec.AssumeRolePolicyDocument), &policyDocumentB)
-
-	if !reflect.DeepEqual(policyDocumentA, policyDocumentB) {
-		delta.Add("Spec.AssumeRolePolicyDocument", a.ko.Spec.AssumeRolePolicyDocument, b.ko.Spec.AssumeRolePolicyDocument)
 	}
 }
 


### PR DESCRIPTION
## Description

Fix perpetual `UpdateAssumeRolePolicy` calls caused by false diffs on `AssumeRolePolicyDocument` when AWS returns semantically equivalent policies with reordered arrays.

- Configure `AssumeRolePolicyDocument` with `is_iam_policy: true` in `generator.yaml`, replacing the previous `compare.is_ignored: true` + custom hook approach.
- Remove the manual `compareAssumeRolePolicyDocument` function from `hooks.go` — the generated `delta.go` now uses `ackcompare.IAMPolicyDocumentEqual` which handles statement ordering, JSON key ordering, string-vs-array normalization, and array element ordering.
- Upgrade runtime to pick up the fixed `aws-iam-policy` library with order-independent comparisons.

## Why is this needed

Fixes: [aws-controllers-k8s/community#2142](https://github.com/aws-controllers-k8s/community/issues/2875)

## How Has This Been Tested?

Added `delta_test.go` with 14 test cases covering the exact issue scenario (reordered `Principal.Service` arrays and `Condition` keys), plus whitespace, statement ordering, Action string-vs-array, and actual diff detection.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
