### PR TITLE
fix: detach role from instance profiles before deletion

### DIFF
--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -535,6 +535,45 @@ func (rm *resourceManager) removeTags(
 	return err
 }
 
+// removeFromInstanceProfiles lists all instance profiles that the role is
+// attached to and removes the role from each of them. This is required before
+// deleting a role, because IAM will reject a DeleteRole call if the role is
+// still attached to any instance profiles (e.g. those created by EKS Auto Mode).
+func (rm *resourceManager) removeFromInstanceProfiles(
+	ctx context.Context,
+	r *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.removeFromInstanceProfiles")
+	defer func() { exit(err) }()
+
+	roleName := r.ko.Spec.Name
+	input := &svcsdk.ListInstanceProfilesForRoleInput{
+		RoleName: roleName,
+	}
+
+	paginator := svcsdk.NewListInstanceProfilesForRolePaginator(rm.sdkapi, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		rm.metrics.RecordAPICall("READ_MANY", "ListInstanceProfilesForRole", err)
+		if err != nil {
+			return err
+		}
+		for _, ip := range page.InstanceProfiles {
+			removeInput := &svcsdk.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: ip.InstanceProfileName,
+				RoleName:            roleName,
+			}
+			_, err = rm.sdkapi.RemoveRoleFromInstanceProfile(ctx, removeInput)
+			rm.metrics.RecordAPICall("UPDATE", "RemoveRoleFromInstanceProfile", err)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func decodeDocument(encoded string) (string, error) {
 	return url.QueryUnescape(encoded)
 }

--- a/templates/hooks/role/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/role/sdk_delete_pre_build_request.go.tpl
@@ -8,3 +8,9 @@
 	if err := rm.syncInlinePolicies(ctx, &resource{ko: roleCpy}, r); err != nil {
 		return nil, err
 	}
+	// Remove the role from all instance profiles it is attached to.
+	// This handles cases where external systems (e.g. EKS Auto Mode) have
+	// attached the role to instance profiles not managed by ACK.
+	if err := rm.removeFromInstanceProfiles(ctx, r); err != nil {
+		return nil, err
+	}

--- a/test/e2e/role.py
+++ b/test/e2e/role.py
@@ -162,3 +162,17 @@ def get_assume_role_policy(role_name):
     except c.exceptions.NoSuchEntityException:
         return None
 
+
+def get_instance_profiles(role_name):
+    """Returns a list of instance profile names that the supplied Role is
+    attached to.
+
+    If no such Role exists, returns None.
+    """
+    c = boto3.client('iam')
+    try:
+        resp = c.list_instance_profiles_for_role(RoleName=role_name)
+        return [ip['InstanceProfileName'] for ip in resp['InstanceProfiles']]
+    except c.exceptions.NoSuchEntityException:
+        return None
+

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -17,6 +17,7 @@ import logging
 import json
 import time
 
+import boto3
 import pytest
 
 from acktest.k8s import condition
@@ -388,3 +389,89 @@ class TestRole:
 
         user_policies = get_bootstrap_resources().AdoptedRole.managed_policies
         assert set(cr['spec']['policies']) == set(user_policies) 
+
+
+@service_marker
+class TestRoleDeleteWithInstanceProfile:
+    """Tests that a Role can be deleted even when it is attached to an
+    instance profile not managed by ACK (e.g. created by EKS Auto Mode).
+    """
+
+    def test_delete_role_attached_to_external_instance_profile(self):
+        """Create a Role CR, externally attach it to an instance profile via
+        boto3 (simulating EKS Auto Mode), then delete the Role CR and verify
+        deletion succeeds without DeleteConflict error.
+        """
+        iam_client = boto3.client('iam')
+        role_name = random_suffix_name("role-ip-detach", 24)
+        instance_profile_name = random_suffix_name("ext-ip-test", 24)
+
+        # Create the Role CR via K8s
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements['ROLE_NAME'] = role_name
+        replacements['ROLE_DESCRIPTION'] = "role for instance profile detach test"
+        replacements['MAX_SESSION_DURATION'] = str(MAX_SESS_DURATION)
+
+        resource_data = load_resource(
+            "role_simple",
+            additional_replacements=replacements,
+        )
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, ROLE_RESOURCE_PLURAL,
+            role_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        assert cr is not None
+
+        role.wait_until_exists(role_name)
+
+        # Externally create an instance profile and attach the role (simulates
+        # what EKS Auto Mode does when nodes launch)
+        try:
+            iam_client.create_instance_profile(
+                InstanceProfileName=instance_profile_name,
+            )
+            iam_client.add_role_to_instance_profile(
+                InstanceProfileName=instance_profile_name,
+                RoleName=role_name,
+            )
+
+            # Verify the role is attached
+            resp = iam_client.list_instance_profiles_for_role(RoleName=role_name)
+            assert len(resp['InstanceProfiles']) == 1
+            assert resp['InstanceProfiles'][0]['InstanceProfileName'] == instance_profile_name
+
+            # Delete the Role CR — this should succeed because the controller
+            # detaches the role from all instance profiles before calling DeleteRole
+            _, deleted = k8s.delete_custom_resource(
+                ref,
+                period_length=DELETE_WAIT_AFTER_SECONDS,
+            )
+            assert deleted
+
+            role.wait_until_deleted(role_name)
+
+            # Verify the instance profile still exists but role is detached
+            resp = iam_client.get_instance_profile(
+                InstanceProfileName=instance_profile_name,
+            )
+            assert len(resp['InstanceProfile']['Roles']) == 0
+
+        finally:
+            # Cleanup: delete the externally-created instance profile
+            try:
+                # Remove role from instance profile if still attached (in case test failed)
+                iam_client.remove_role_from_instance_profile(
+                    InstanceProfileName=instance_profile_name,
+                    RoleName=role_name,
+                )
+            except iam_client.exceptions.NoSuchEntityException:
+                pass
+            try:
+                iam_client.delete_instance_profile(
+                    InstanceProfileName=instance_profile_name,
+                )
+            except iam_client.exceptions.NoSuchEntityException:
+                pass


### PR DESCRIPTION
When external systems (e.g. EKS Auto Mode) attach a role to instance profiles not managed by ACK, the DeleteRole API call fails with DeleteConflict. This fix adds a pre-delete step that calls ListInstanceProfilesForRole and RemoveRoleFromInstanceProfile for each attached instance profile before proceeding with role deletion.

Changes:
- pkg/resource/role/hooks.go: add removeFromInstanceProfiles()
- templates/hooks/role/sdk_delete_pre_build_request.go.tpl: invoke it
- test/e2e: add e2e test verifying role deletion with external instance profile attachment succeeds


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
