### PR TITLE
fix: detach role from instance profiles before deletion

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2026-05-23T10:20:05Z"
+  build_date: "2026-05-23T10:46:00Z"
   build_hash: 8b46cc24f655c464e4221f893e710865d7ae600a
-  go_version: go1.26.2
+  go_version: go1.26.3
   version: v0.59.0-2-g8b46cc2
 api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
 api_version: v1alpha1

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:43:12Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
+  build_date: "2026-05-23T10:20:05Z"
+  build_hash: 8b46cc24f655c464e4221f893e710865d7ae600a
+  go_version: go1.26.2
+  version: v0.59.0-2-g8b46cc2
 api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/role/hooks.go
+++ b/pkg/resource/role/hooks.go
@@ -15,6 +15,7 @@ package role
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -22,6 +23,7 @@ import (
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/iam"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	smithy "github.com/aws/smithy-go"
 	"github.com/samber/lo"
 
 	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
@@ -533,6 +535,70 @@ func (rm *resourceManager) removeTags(
 	_, err = rm.sdkapi.UntagRole(ctx, input)
 	rm.metrics.RecordAPICall("UPDATE", "UntagRole", err)
 	return err
+}
+
+// removeFromInstanceProfiles lists all instance profiles that the role is
+// attached to and removes the role from each of them. This is required before
+// deleting a role, because IAM will reject a DeleteRole call if the role is
+// still attached to any instance profiles (e.g. those created by EKS Auto Mode).
+//
+// NoSuchEntity errors are ignored on both API calls because:
+//   - ListInstanceProfilesForRole may return NoSuchEntity if the role was already
+//     deleted from AWS (e.g. by another controller or manual cleanup).
+//   - RemoveRoleFromInstanceProfile may return NoSuchEntity if the instance
+//     profile was deleted between the list and remove calls (race with EKS
+//     cleaning up its own instance profiles).
+//
+// In both cases the pre-condition for role deletion is already satisfied.
+func (rm *resourceManager) removeFromInstanceProfiles(
+	ctx context.Context,
+	r *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.removeFromInstanceProfiles")
+	defer func() { exit(err) }()
+
+	roleName := r.ko.Spec.Name
+	input := &svcsdk.ListInstanceProfilesForRoleInput{
+		RoleName: roleName,
+	}
+
+	paginator := svcsdk.NewListInstanceProfilesForRolePaginator(rm.sdkapi, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		rm.metrics.RecordAPICall("READ_MANY", "ListInstanceProfilesForRole", err)
+		if err != nil {
+			// Role no longer exists in IAM — nothing to detach.
+			if isNoSuchEntityError(err) {
+				return nil
+			}
+			return err
+		}
+		for _, ip := range page.InstanceProfiles {
+			removeInput := &svcsdk.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: ip.InstanceProfileName,
+				RoleName:            roleName,
+			}
+			_, err = rm.sdkapi.RemoveRoleFromInstanceProfile(ctx, removeInput)
+			rm.metrics.RecordAPICall("UPDATE", "RemoveRoleFromInstanceProfile", err)
+			if err != nil {
+				// Instance profile was already deleted or role already
+				// detached — safe to continue.
+				if isNoSuchEntityError(err) {
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// isNoSuchEntityError returns true if the error is an IAM NoSuchEntity error,
+// meaning the referenced resource (role or instance profile) does not exist.
+func isNoSuchEntityError(err error) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchEntity"
 }
 
 func decodeDocument(encoded string) (string, error) {

--- a/pkg/resource/role/sdk.go
+++ b/pkg/resource/role/sdk.go
@@ -492,6 +492,12 @@ func (rm *resourceManager) sdkDelete(
 	if err := rm.syncInlinePolicies(ctx, &resource{ko: roleCpy}, r); err != nil {
 		return nil, err
 	}
+	// Remove the role from all instance profiles it is attached to.
+	// This handles cases where external systems (e.g. EKS Auto Mode) have
+	// attached the role to instance profiles not managed by ACK.
+	if err := rm.removeFromInstanceProfiles(ctx, r); err != nil {
+		return nil, err
+	}
 
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {

--- a/templates/hooks/role/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/role/sdk_delete_pre_build_request.go.tpl
@@ -8,3 +8,9 @@
 	if err := rm.syncInlinePolicies(ctx, &resource{ko: roleCpy}, r); err != nil {
 		return nil, err
 	}
+	// Remove the role from all instance profiles it is attached to.
+	// This handles cases where external systems (e.g. EKS Auto Mode) have
+	// attached the role to instance profiles not managed by ACK.
+	if err := rm.removeFromInstanceProfiles(ctx, r); err != nil {
+		return nil, err
+	}

--- a/test/e2e/role.py
+++ b/test/e2e/role.py
@@ -162,3 +162,17 @@ def get_assume_role_policy(role_name):
     except c.exceptions.NoSuchEntityException:
         return None
 
+
+def get_instance_profiles(role_name):
+    """Returns a list of instance profile names that the supplied Role is
+    attached to.
+
+    If no such Role exists, returns None.
+    """
+    c = boto3.client('iam')
+    try:
+        resp = c.list_instance_profiles_for_role(RoleName=role_name)
+        return [ip['InstanceProfileName'] for ip in resp['InstanceProfiles']]
+    except c.exceptions.NoSuchEntityException:
+        return None
+

--- a/test/e2e/tests/test_role.py
+++ b/test/e2e/tests/test_role.py
@@ -17,6 +17,7 @@ import logging
 import json
 import time
 
+import boto3
 import pytest
 
 from acktest.k8s import condition
@@ -388,3 +389,172 @@ class TestRole:
 
         user_policies = get_bootstrap_resources().AdoptedRole.managed_policies
         assert set(cr['spec']['policies']) == set(user_policies) 
+
+
+@service_marker
+class TestRoleDeleteWithInstanceProfile:
+    """Tests that a Role can be deleted even when it is attached to an
+    instance profile not managed by ACK (e.g. created by EKS Auto Mode).
+    """
+
+    def test_delete_role_attached_to_external_instance_profile(self):
+        """Create a Role CR, externally attach it to an instance profile via
+        boto3 (simulating EKS Auto Mode), then delete the Role CR and verify
+        deletion succeeds without DeleteConflict error.
+        """
+        iam_client = boto3.client('iam')
+        role_name = random_suffix_name("role-ip-detach", 24)
+        instance_profile_name = random_suffix_name("ext-ip-test", 24)
+
+        # Create the Role CR via K8s
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements['ROLE_NAME'] = role_name
+        replacements['ROLE_DESCRIPTION'] = "role for instance profile detach test"
+        replacements['MAX_SESSION_DURATION'] = str(MAX_SESS_DURATION)
+
+        resource_data = load_resource(
+            "role_simple",
+            additional_replacements=replacements,
+        )
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, ROLE_RESOURCE_PLURAL,
+            role_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        assert cr is not None
+
+        role.wait_until_exists(role_name)
+
+        # Externally create an instance profile and attach the role (simulates
+        # what EKS Auto Mode does when nodes launch)
+        try:
+            iam_client.create_instance_profile(
+                InstanceProfileName=instance_profile_name,
+            )
+            iam_client.add_role_to_instance_profile(
+                InstanceProfileName=instance_profile_name,
+                RoleName=role_name,
+            )
+
+            # Verify the role is attached
+            resp = iam_client.list_instance_profiles_for_role(RoleName=role_name)
+            assert len(resp['InstanceProfiles']) == 1
+            assert resp['InstanceProfiles'][0]['InstanceProfileName'] == instance_profile_name
+
+            # Delete the Role CR — this should succeed because the controller
+            # detaches the role from all instance profiles before calling DeleteRole
+            _, deleted = k8s.delete_custom_resource(
+                ref,
+                period_length=DELETE_WAIT_AFTER_SECONDS,
+            )
+            assert deleted
+
+            role.wait_until_deleted(role_name)
+
+            # Verify the instance profile still exists but role is detached
+            resp = iam_client.get_instance_profile(
+                InstanceProfileName=instance_profile_name,
+            )
+            assert len(resp['InstanceProfile']['Roles']) == 0
+
+        finally:
+            # Cleanup: delete the externally-created instance profile
+            try:
+                # Remove role from instance profile if still attached (in case test failed)
+                iam_client.remove_role_from_instance_profile(
+                    InstanceProfileName=instance_profile_name,
+                    RoleName=role_name,
+                )
+            except iam_client.exceptions.NoSuchEntityException:
+                pass
+            try:
+                iam_client.delete_instance_profile(
+                    InstanceProfileName=instance_profile_name,
+                )
+            except iam_client.exceptions.NoSuchEntityException:
+                pass
+
+    def test_delete_role_after_instance_profile_already_deleted(self):
+        """Create a Role CR, externally attach it to an instance profile,
+        then delete the instance profile BEFORE deleting the Role CR.
+        This simulates EKS cleaning up its instance profile while the
+        controller is still trying to delete the role. The controller
+        should handle the NoSuchEntity gracefully.
+        """
+        iam_client = boto3.client('iam')
+        role_name = random_suffix_name("role-ip-gone", 24)
+        instance_profile_name = random_suffix_name("ext-ip-gone", 24)
+
+        # Create the Role CR via K8s
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements['ROLE_NAME'] = role_name
+        replacements['ROLE_DESCRIPTION'] = "role for instance profile already-deleted test"
+        replacements['MAX_SESSION_DURATION'] = str(MAX_SESS_DURATION)
+
+        resource_data = load_resource(
+            "role_simple",
+            additional_replacements=replacements,
+        )
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, ROLE_RESOURCE_PLURAL,
+            role_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        assert cr is not None
+
+        role.wait_until_exists(role_name)
+
+        try:
+            # Externally create instance profile and attach role
+            iam_client.create_instance_profile(
+                InstanceProfileName=instance_profile_name,
+            )
+            iam_client.add_role_to_instance_profile(
+                InstanceProfileName=instance_profile_name,
+                RoleName=role_name,
+            )
+
+            # Verify the role is attached
+            resp = iam_client.list_instance_profiles_for_role(RoleName=role_name)
+            assert len(resp['InstanceProfiles']) == 1
+
+            # Simulate EKS cleaning up: remove role and delete instance profile
+            # BEFORE the Role CR is deleted
+            iam_client.remove_role_from_instance_profile(
+                InstanceProfileName=instance_profile_name,
+                RoleName=role_name,
+            )
+            iam_client.delete_instance_profile(
+                InstanceProfileName=instance_profile_name,
+            )
+
+            # Now delete the Role CR — the controller will call
+            # ListInstanceProfilesForRole which returns empty (role has no
+            # attached profiles anymore). This must succeed.
+            _, deleted = k8s.delete_custom_resource(
+                ref,
+                period_length=DELETE_WAIT_AFTER_SECONDS,
+            )
+            assert deleted
+
+            role.wait_until_deleted(role_name)
+
+        finally:
+            # Cleanup in case of test failure
+            try:
+                iam_client.remove_role_from_instance_profile(
+                    InstanceProfileName=instance_profile_name,
+                    RoleName=role_name,
+                )
+            except iam_client.exceptions.NoSuchEntityException:
+                pass
+            try:
+                iam_client.delete_instance_profile(
+                    InstanceProfileName=instance_profile_name,
+                )
+            except iam_client.exceptions.NoSuchEntityException:
+                pass


### PR DESCRIPTION
## fix: detach role from all instance profiles before deletion

### Problem

When external systems (e.g. EKS Auto Mode) attach an ACK-managed IAM Role to instance profiles, deleting the Role CR sometimes fails with `DeleteConflict: Cannot delete entity, must remove roles from instance profile first`.

### Fix

Added `removeFromInstanceProfiles()` to the pre-delete hook — calls `ListInstanceProfilesForRole` → `RemoveRoleFromInstanceProfile` for each, before `DeleteRole`.

### Changes

- `pkg/resource/role/hooks.go` — new `removeFromInstanceProfiles()` method
- `templates/hooks/role/sdk_delete_pre_build_request.go.tpl` — invoke in pre-delete hook
- `test/e2e/tests/test_role.py` — e2e test simulating external instance profile attachment + role deletion
- `test/e2e/role.py` — added `get_instance_profiles()` helper

### Testing

`TestRoleDeleteWithInstanceProfile`: creates role via K8s, attaches to instance profile via boto3 (simulating EKS Auto Mode), deletes role CR, verifies clean deletion without `DeleteConflict`.