### PR TITLE
Mark Policy.PolicyDocument as is_iam_policy for semantic comparison

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:43:12Z"
+  build_date: "2026-06-17T20:03:58Z"
   build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
+  go_version: go1.26.0
   version: v0.59.1
 api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 5a412f0cf6a9b9774ccbe2c7214baf1b14bdb89e
+  file_checksum: 1339c27fce2a31f19582bb8951f169b93d4af15b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -178,6 +178,8 @@ resources:
           method: Create
       Path:
         late_initialize: {}
+      PolicyDocument:
+        is_iam_policy: true
       Tags:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -178,6 +178,8 @@ resources:
           method: Create
       Path:
         late_initialize: {}
+      PolicyDocument:
+        is_iam_policy: true
       Tags:
         compare:
           is_ignored: true

--- a/pkg/resource/policy/delta.go
+++ b/pkg/resource/policy/delta.go
@@ -66,7 +66,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument) {
 		delta.Add("Spec.PolicyDocument", a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument)
 	} else if a.ko.Spec.PolicyDocument != nil && b.ko.Spec.PolicyDocument != nil {
-		if *a.ko.Spec.PolicyDocument != *b.ko.Spec.PolicyDocument {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.PolicyDocument, *b.ko.Spec.PolicyDocument); err != nil || !equal {
 			delta.Add("Spec.PolicyDocument", a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument)
 		}
 	}


### PR DESCRIPTION
## Problem

The IAM Policy `PolicyDocument` field is a JSON string containing an IAM policy document. Without the `is_iam_policy` annotation, the controller uses raw string comparison (`!=`) for delta detection. This causes unnecessary reconciliation loops when AWS returns the policy document with different whitespace, key ordering, or URL-encoded characters than what was originally submitted.

Note that the Role resource's `AssumeRolePolicyDocument` already uses `is_iam_policy: true` correctly — this brings the Policy resource to parity.

## Solution

Added `is_iam_policy: true` to the `Policy.PolicyDocument` field in `generator.yaml`. This makes the generated code use `ackcompare.IAMPolicyDocumentEqual()` which URL-decodes and performs semantic JSON comparison of both policy documents.

## Changes

- `generator.yaml`: Added `is_iam_policy: true` for `Policy.PolicyDocument`
- `pkg/resource/policy/delta.go`: Regenerated — now uses `IAMPolicyDocumentEqual` instead of `!=`

## Testing

- `go build -o bin/controller ./cmd/controller` — compiles cleanly
- Existing E2E test (`test_policy.py::TestPolicy::test_crud`) already validates PolicyDocument create and update flow (creates policy, updates document, verifies version bump to v2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.