### PR TITLE
Remove aws-sdk-go import

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-08-13T17:52:42Z"
-  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
+  build_date: "2026-08-18T01:02:29Z"
+  build_hash: d4aaca5e1dd6acfd81094936dc825ad30d2bbb39
   go_version: go1.26.5
-  version: v0.62.1-dirty
+  version: v0.62.1-4-gd4aaca5
 api_directory_checksum: 2569e54a9e72c9cbbc89e51d97e00179a82731c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:45:44Z"
-  build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
+  build_date: "2026-08-13T17:52:42Z"
+  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.5
-  version: v0.62.0
-api_directory_checksum: fcb205ac280ed1b0f107a291e5ea43d93c0991e9
+  version: v0.62.1-dirty
+api_directory_checksum: 2569e54a9e72c9cbbc89e51d97e00179a82731c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -17,14 +17,12 @@ package v1alpha1
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Hack to avoid import errors during build...
 var (
 	_ = &metav1.Time{}
-	_ = &aws.JSONValue{}
 	_ = ackv1alpha1.AWSAccountID("")
 )
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"os"
+	goruntime "runtime"
+	"runtime/debug"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -56,6 +58,21 @@ var (
 	scheme             = runtime.NewScheme()
 	setupLog           = ctrlrt.Log.WithName("setup")
 )
+
+// depVersion returns the module version of the given dependency import path,
+// as recorded in the binary's build info, or "unknown" if it cannot be found.
+func depVersion(path string) string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == path {
+			return dep.Version
+		}
+	}
+	return "unknown"
+}
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -149,6 +166,17 @@ func main() {
 	setupLog.Info(
 		"initializing service controller",
 		"aws.service", awsServiceAlias,
+		"version", version.GitVersion,
+	)
+	setupLog.V(1).Info(
+		"build details",
+		"aws.service", awsServiceAlias,
+		"gitCommit", version.GitCommit,
+		"buildDate", version.BuildDate,
+		"goVersion", goruntime.Version(),
+		"ackGenerateVersion", version.ACKGenerateVersion,
+		"ackRuntimeVersion", depVersion("github.com/aws-controllers-k8s/runtime"),
+		"awsSDKGoV2Version", depVersion("github.com/aws/aws-sdk-go-v2"),
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/aws-controllers-k8s/runtime v0.62.0
-	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.38.8
 	github.com/aws/smithy-go v1.22.2
@@ -49,7 +48,6 @@ require (
 	github.com/itchyny/gojq v0.12.6 // indirect
 	github.com/itchyny/timefmt-go v0.1.3 // indirect
 	github.com/jaypipes/envutil v1.0.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/aws-controllers-k8s/runtime v0.62.0 h1:6Dw2zbk7565qatREuVwFttEAAFK0O9osavESH5RFX2I=
 github.com/aws-controllers-k8s/runtime v0.62.0/go.mod h1:U0E02HFCvRnLQplApOIeTPDBiRBKXjvyaRhb475bcGs=
-github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
-github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
 github.com/aws/aws-sdk-go-v2 v1.34.0/go.mod h1:JgstGg0JjWU1KpVJjD5H0y0yyAIpSdKEq556EI6yOOM=
 github.com/aws/aws-sdk-go-v2/config v1.28.6 h1:D89IKtGrs/I3QXOLNTH93NJYtDhm8SYa9Q5CsPShmyo=
@@ -87,10 +85,6 @@ github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921i
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jaypipes/envutil v1.0.0 h1:u6Vwy9HwruFihoZrL0bxDLCa/YNadGVwKyPElNmZWow=
 github.com/jaypipes/envutil v1.0.0/go.mod h1:vgIRDly+xgBq0eeZRcflOHMMobMwgC6MkMbxo/Nw65M=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -200,8 +194,6 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/resource/role/delta_test.go
+++ b/pkg/resource/role/delta_test.go
@@ -16,7 +16,7 @@ package role
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 
 	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"

--- a/pkg/util/tags.go
+++ b/pkg/util/tags.go
@@ -16,7 +16,6 @@ package util
 import (
 	svcapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
-	svcsdk "github.com/aws/aws-sdk-go/service/iam"
 )
 
 // computeTagsDelta compares two Tag arrays and return two different list
@@ -56,19 +55,6 @@ func EqualTags(
 ) bool {
 	addedOrUpdated, removed := computeTagsDelta(a, b)
 	return len(addedOrUpdated) == 0 && len(removed) == 0
-}
-
-// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
-// array.
-func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []*svcsdk.Tag {
-	tags := make([]*svcsdk.Tag, len(rTags))
-	for i := range rTags {
-		tags[i] = &svcsdk.Tag{
-			Key:   rTags[i].Key,
-			Value: rTags[i].Value,
-		}
-	}
-	return tags
 }
 
 func equalStrings(a, b *string) bool {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1-dirty"
-	ACKGenerateBuildDate = "2026-08-13T17:52:42Z"
+	ACKGenerateVersion   = "v0.62.1-4-gd4aaca5"
+	ACKGenerateBuildDate = "2026-08-18T01:02:29Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,8 +15,18 @@
 
 package version
 
+// GitVersion, GitCommit, and BuildDate describe the service controller build
+// and are injected at controller build time via -ldflags.
 var (
 	GitVersion string
 	GitCommit  string
 	BuildDate  string
+)
+
+// ACKGenerateVersion and ACKGenerateBuildDate identify the ack-generate build
+// that generated this controller's code. They are baked in at code-generation
+// time and are immutable for the life of the generated code.
+const (
+	ACKGenerateVersion   = "v0.62.1-dirty"
+	ACKGenerateBuildDate = "2026-08-13T17:52:42Z"
 )


### PR DESCRIPTION
Issue #, if available: [2783](https://github.com/aws-controllers-k8s/community/issues/2783)

Description of changes:
PR regenerating iam-controller with code-generator version from https://github.com/aws-controllers-k8s/code-generator/pull/733 to validate removal of `aws-sdk-go` from service controller. In addition to re-generated code this PR updates tests and custom code to either update to `aws-sdk-go-v2` or removal references.

- Regenerate controller with code-generator version that no longer forces import of aws-sdk-go in types.go
- Update delta_test.go to use aws-sdk-go-v2 utility functions
- Remove unused sdkTagsFromResourceTags function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
